### PR TITLE
fix: update action rendering in ModifyRecordListRecordActionsListener to avoid button issue

### DIFF
--- a/Classes/EventListener/ModifyRecordListRecordActionsListener.php
+++ b/Classes/EventListener/ModifyRecordListRecordActionsListener.php
@@ -7,7 +7,6 @@ use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Localization\LanguageService;
-use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 use Xima\XimaTypo3ContentPlanner\Domain\Repository\RecordRepository;
 use Xima\XimaTypo3ContentPlanner\Domain\Repository\StatusRepository;
 use Xima\XimaTypo3ContentPlanner\Service\SelectionBuilder\ListSelectionService;

--- a/Classes/EventListener/ModifyRecordListRecordActionsListener.php
+++ b/Classes/EventListener/ModifyRecordListRecordActionsListener.php
@@ -7,6 +7,7 @@ use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 use Xima\XimaTypo3ContentPlanner\Domain\Repository\RecordRepository;
 use Xima\XimaTypo3ContentPlanner\Domain\Repository\StatusRepository;
 use Xima\XimaTypo3ContentPlanner\Service\SelectionBuilder\ListSelectionService;
@@ -55,7 +56,7 @@ final class ModifyRecordListRecordActionsListener
 
         $title = $status ? $status->getTitle() : 'Status';
         $icon = $status ? $status->getColoredIcon() : 'flag-gray';
-        $action = '<div class="btn-group" style="margin-left:10px;">
+        $action = '
                 <a href="#" class="btn btn-default dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" title="' . $title . '">'
             . $this->iconFactory->getIcon($icon, Icon::SIZE_SMALL)->render() . '</a><ul class="dropdown-menu">';
 
@@ -65,13 +66,14 @@ final class ModifyRecordListRecordActionsListener
         }
 
         $action .= '</ul>';
-        $action .= '</div>';
+        $action .= '';
+
         $event->setAction(
             $action,
             'Status',
             'primary',
-            '',
             'delete',
+            '',
         );
     }
 


### PR DESCRIPTION
Using the `after: 'delete'` positioning with the `ModifyRecordListRecordActionsEvent` seems to be broken for the last entry. 

![Bildschirmfoto 2025-04-23 um 18 27 51](https://github.com/user-attachments/assets/afafdf95-3aa0-4dea-9b19-08bd7a5ba722)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the appearance of the dropdown action menu by removing the outer button group styling for a cleaner look.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->