### PR TITLE
cleanup: replace deprecated Icon usage with IconSize

### DIFF
--- a/Classes/EventListener/ModifyRecordListRecordActionsListener.php
+++ b/Classes/EventListener/ModifyRecordListRecordActionsListener.php
@@ -4,8 +4,8 @@ namespace Xima\XimaTypo3ContentPlanner\EventListener;
 
 use TYPO3\CMS\Backend\RecordList\Event\ModifyRecordListRecordActionsEvent;
 use TYPO3\CMS\Core\Http\ServerRequest;
-use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Imaging\IconSize;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use Xima\XimaTypo3ContentPlanner\Domain\Repository\RecordRepository;
 use Xima\XimaTypo3ContentPlanner\Domain\Repository\StatusRepository;
@@ -57,7 +57,7 @@ final class ModifyRecordListRecordActionsListener
         $icon = $status ? $status->getColoredIcon() : 'flag-gray';
         $action = '
                 <a href="#" class="btn btn-default dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" title="' . $title . '">'
-            . $this->iconFactory->getIcon($icon, Icon::SIZE_SMALL)->render() . '</a><ul class="dropdown-menu">';
+            . $this->iconFactory->getIcon($icon, IconSize::SMALL)->render() . '</a><ul class="dropdown-menu">';
 
         $actionsToAdd = $this->htmlSelectionService->generateSelection($table, $uid);
         foreach ($actionsToAdd as $actionToAdd) {

--- a/Classes/EventListener/ModifyRecordListTableActionsListener.php
+++ b/Classes/EventListener/ModifyRecordListTableActionsListener.php
@@ -2,11 +2,12 @@
 
 namespace Xima\XimaTypo3ContentPlanner\EventListener;
 
+use Psr\Http\Message\UriInterface;
 use TYPO3\CMS\Backend\RecordList\Event\ModifyRecordListTableActionsEvent;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Http\ServerRequest;
-use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Imaging\IconSize;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use Xima\XimaTypo3ContentPlanner\Domain\Model\Status;
 use Xima\XimaTypo3ContentPlanner\Domain\Repository\StatusRepository;
@@ -44,21 +45,21 @@ final class ModifyRecordListTableActionsListener
 
         $action = '<div class="btn-group" style="margin-left:10px;">
                 <a href="#" class="btn btn-sm btn-default dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" title="test">' .
-            $this->iconFactory->getIcon('flag-gray', Icon::SIZE_SMALL)->render() . '</a><ul class="dropdown-menu">';
+            $this->iconFactory->getIcon('flag-gray', IconSize::SMALL)->render() . '</a><ul class="dropdown-menu">';
 
         $actionsToAdd = [];
 
         foreach ($allStatus as $statusEntry) {
             $url = $this->buildUri($event, $statusEntry);
             $actionsToAdd[$statusEntry->getUid()] = '<li><a class="dropdown-item dropdown-item-spaced" href="' . htmlspecialchars($url) . '" title="' . $statusEntry->getTitle() . '">'
-                . $this->iconFactory->getIcon($statusEntry->getColoredIcon(), Icon::SIZE_SMALL)->render() . $statusEntry->getTitle() . '</a></li>';
+                . $this->iconFactory->getIcon($statusEntry->getColoredIcon(), IconSize::SMALL)->render() . $statusEntry->getTitle() . '</a></li>';
         }
         $actionsToAdd['divider'] = '<li><hr class="dropdown-divider"></li>';
 
         // reset
         $url = $this->buildUri($event, null);
         $actionsToAdd['reset'] = '<li><a class="dropdown-item dropdown-item-spaced" href="' . htmlspecialchars($url) . '" title="' . $this->getLanguageService()->sL('LLL:EXT:xima_typo3_content_planner/Resources/Private/Language/locallang_be.xlf:reset') . '">'
-            . $this->iconFactory->getIcon('actions-close', Icon::SIZE_SMALL)->render() . $this->getLanguageService()->sL('LLL:EXT:xima_typo3_content_planner/Resources/Private/Language/locallang_be.xlf:reset') . '</a></li>';
+            . $this->iconFactory->getIcon('actions-close', IconSize::SMALL)->render() . $this->getLanguageService()->sL('LLL:EXT:xima_typo3_content_planner/Resources/Private/Language/locallang_be.xlf:reset') . '</a></li>';
 
         foreach ($actionsToAdd as $actionToAdd) {
             $action .= $actionToAdd;
@@ -74,7 +75,7 @@ final class ModifyRecordListTableActionsListener
         );
     }
 
-    private function buildUri(ModifyRecordListTableActionsEvent $event, ?Status $statusEntry): \Psr\Http\Message\UriInterface
+    private function buildUri(ModifyRecordListTableActionsEvent $event, ?Status $statusEntry): UriInterface
     {
         $dataArray = [
             $event->getTable() => [],

--- a/Classes/Service/SelectionBuilder/ListSelectionService.php
+++ b/Classes/Service/SelectionBuilder/ListSelectionService.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Xima\XimaTypo3ContentPlanner\Service\SelectionBuilder;
 
 use TYPO3\CMS\Backend\Routing\UriBuilder;
-use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Imaging\IconSize;
 use Xima\XimaTypo3ContentPlanner\Configuration;
 use Xima\XimaTypo3ContentPlanner\Domain\Model\Dto\StatusItem;
 use Xima\XimaTypo3ContentPlanner\Domain\Model\Status;
@@ -39,7 +39,7 @@ class ListSelectionService extends AbstractSelectionService implements Selection
                 '<li><a class="dropdown-item dropdown-item-spaced" href="%s" title="%s">%s%s</a></li>',
                 htmlspecialchars($this->buildUriForStatusChange($table, $uid, $status, $record['pid'])->__toString()),
                 $status->getTitle(),
-                $this->iconFactory->getIcon($status->getColoredIcon(), Icon::SIZE_SMALL)->render(),
+                $this->iconFactory->getIcon($status->getColoredIcon(), IconSize::SMALL)->render(),
                 $status->getTitle()
             )
         ;
@@ -57,7 +57,7 @@ class ListSelectionService extends AbstractSelectionService implements Selection
                 '<li><a class="dropdown-item dropdown-item-spaced" href="%s" title="%s">%s%s</a></li>',
                 htmlspecialchars($this->buildUriForStatusChange($table, $uid, null, $record['pid'])->__toString()),
                 $this->getLanguageService()->sL('LLL:EXT:' . Configuration::EXT_KEY . '/Resources/Private/Language/locallang_be.xlf:reset'),
-                $this->iconFactory->getIcon('actions-close', Icon::SIZE_SMALL)->render(),
+                $this->iconFactory->getIcon('actions-close', IconSize::SMALL)->render(),
                 $this->getLanguageService()->sL('LLL:EXT:' . Configuration::EXT_KEY . '/Resources/Private/Language/locallang_be.xlf:reset')
             )
         ;
@@ -89,7 +89,7 @@ class ListSelectionService extends AbstractSelectionService implements Selection
                 $uid,
                 UrlHelper::getNewCommentUrl($table, $uid),
                 UrlHelper::getContentStatusPropertiesEditUrl($table, $uid),
-                $this->iconFactory->getIcon('content-message', Icon::SIZE_SMALL)->render(),
+                $this->iconFactory->getIcon('content-message', IconSize::SMALL)->render(),
                 ($record['tx_ximatypo3contentplanner_comments'] ?  $this->commentRepository->countAllByRecord($record['uid'], $table) . ' ' : '') . $this->getLanguageService()->sL('LLL:EXT:' . Configuration::EXT_KEY . '/Resources/Private/Language/locallang_be.xlf:comments')
             )
         ;
@@ -111,7 +111,7 @@ class ListSelectionService extends AbstractSelectionService implements Selection
                 $uid,
                 UrlHelper::getNewCommentUrl($table, $uid),
                 UrlHelper::getContentStatusPropertiesEditUrl($table, $uid),
-                $this->iconFactory->getIcon('actions-check-square', Icon::SIZE_SMALL)->render(),
+                $this->iconFactory->getIcon('actions-check-square', IconSize::SMALL)->render(),
                 "$todoResolved/$todoTotal " . $this->getLanguageService()->sL('LLL:EXT:' . Configuration::EXT_KEY . '/Resources/Private/Language/locallang_be.xlf:comments.todo')
             )
         ;

--- a/Classes/Utility/IconHelper.php
+++ b/Classes/Utility/IconHelper.php
@@ -5,18 +5,17 @@ declare(strict_types=1);
 namespace Xima\XimaTypo3ContentPlanner\Utility;
 
 use TYPO3\CMS\Backend\Backend\Avatar\Avatar;
-use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Imaging\IconSize;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Xima\XimaTypo3ContentPlanner\Domain\Model\Status;
 
 class IconHelper
 {
-    public static function getIconByIdentifier(string $identifier, string $size = Icon::SIZE_SMALL): string
+    public static function getIconByIdentifier(string $identifier, IconSize $size = IconSize::SMALL): string
     {
         $iconFactory = GeneralUtility::makeInstance(IconFactory::class);
-        $icon = $iconFactory->getIcon($identifier, $size);
-        return $icon->render();
+        return $iconFactory->getIcon($identifier, $size)->render();
     }
 
     public static function getIconByStatusUid(int $uid, bool $render = false): string
@@ -25,14 +24,14 @@ class IconHelper
         return self::getIconByStatus($status, $render);
     }
 
-    public static function getIconByStatus(?Status $status, bool $render = false, string $size = Icon::SIZE_SMALL): string
+    public static function getIconByStatus(?Status $status, bool $render = false, IconSize $size = IconSize::SMALL): string
     {
         $iconFactory = GeneralUtility::makeInstance(IconFactory::class);
         $icon = $iconFactory->getIcon($status ? $status->getColoredIcon() : 'flag-gray', $size);
         return $render ? $icon->render() : $icon->getIdentifier();
     }
 
-    public static function getIconByRecord(string $table, array|bool $record, bool $render = false, string $size = Icon::SIZE_SMALL): string
+    public static function getIconByRecord(string $table, array|bool $record, bool $render = false, IconSize $size = IconSize::SMALL): string
     {
         if (!$record) {
             return '';
@@ -53,7 +52,6 @@ class IconHelper
         if (!$user) {
             return '';
         }
-        $avatar = GeneralUtility::makeInstance(Avatar::class);
-        return $avatar->render($user, $size, true);
+        return GeneralUtility::makeInstance(Avatar::class)->render($user, $size, true);
     }
 }


### PR DESCRIPTION
Fixes #76 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated icon rendering to use the latest icon size constants, ensuring compatibility with recent TYPO3 core changes.
  - Improved method signatures for icon helper utilities to use new icon size types.
  - Streamlined internal icon and avatar rendering processes for better maintainability.

- **Style**
  - Simplified code structure for icon and avatar rendering methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->