### PR TITLE
feat: set comment table to hide

### DIFF
--- a/Configuration/TCA/tx_ximatypo3contentplanner_comment.php
+++ b/Configuration/TCA/tx_ximatypo3contentplanner_comment.php
@@ -10,6 +10,7 @@ return [
         'delete' => 'deleted',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
+        'hideTable' => true,
         'typeicon_classes' => [
             'default' => 'content-message',
         ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated backend configuration to hide specific content planner comment entries from certain TYPO3 backend listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->