### PR TITLE
docs: add notes on loading order and automatic DB field generation for additional records

### DIFF
--- a/Documentation/DeveloperCorner/AdditionalRecords.rst
+++ b/Documentation/DeveloperCorner/AdditionalRecords.rst
@@ -15,7 +15,7 @@ By default the Content Planner supports the status functionality only for pages.
     Categories as additional records
 
 ..  note::
-    Keep in mind to consider the loading order of the Content Planner extension. If you want to use the Content Planner for additional records, you need to load the Content Planner extension before the extension that provides the additional records.
+    Keep in mind to consider the loading order of the Content Planner extension. If you want to use the Content Planner for additional records, you need to load the Content Planner extension **before** the extension that provides the additional records.
 
 Follow the steps below to extend the Content Planner to support additional records, e.g. *news* or *tt_content* records:
 
@@ -40,7 +40,7 @@ Follow the steps below to extend the Content Planner to support additional recor
     );
 
 ..  note::
-    With TYPO3 v13 the database fields will be generated automatically, so you don't need to define them by your own: `Feature: #101553 - Auto-create DB fields from TCA columns <https://docs.typo3.org/permalink/changelog:feature-101553-1691166389>`_
+    As of TYPO3 v13, the database fields are generated automatically, so you no longer need to define them yourself: `Feature: #101553 - Auto-create DB fields from TCA columns <https://docs.typo3.org/permalink/changelog:feature-101553-1691166389>`_
 
 3. Register the additional record:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added notes clarifying the required loading order of extensions when supporting additional records in the Content Planner.
  - Updated information for TYPO3 version 13, highlighting automatic generation of necessary database fields for additional records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->