### PR TITLE
fix: avoid implicitly nullable parameters

### DIFF
--- a/Classes/Utility/ViewFactoryHelper.php
+++ b/Classes/Utility/ViewFactoryHelper.php
@@ -12,7 +12,7 @@ use Xima\XimaTypo3ContentPlanner\Configuration;
 
 class ViewFactoryHelper
 {
-    public static function renderView(string $template, array $values, ServerRequestInterface $request = null): string
+    public static function renderView(string $template, array $values, ?ServerRequestInterface $request = null): string
     {
         $typo3Version = GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion();
 
@@ -40,7 +40,7 @@ class ViewFactoryHelper
         return $view->render();
     }
 
-    private static function renderView13(string $template, array $values, ServerRequestInterface $request = null): string
+    private static function renderView13(string $template, array $values, ?ServerRequestInterface $request = null): string
     {
         $viewFactoryData = new \TYPO3\CMS\Core\View\ViewFactoryData(
             templateRootPaths: ['EXT:' . Configuration::EXT_KEY . '/Resources/Private/Templates/'],


### PR DESCRIPTION
Since PHP 8.4 implicitly nullable parameters are deprecated: https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter

This patch avoids displaying deprecations (if they are activated) like:

    PHP Deprecated:  Xima\XimaTypo3ContentPlanner\Utility\ViewFactoryHelper::renderView(): Implicitly marking parameter $request as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/xima/xima-typo3-content-planner/Classes/Utility/ViewFactoryHelper.php on line 15
    PHP Deprecated:  Xima\XimaTypo3ContentPlanner\Utility\ViewFactoryHelper::renderView13(): Implicitly marking parameter $request as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/xima/xima-typo3-content-planner/Classes/Utility/ViewFactoryHelper.php on line 43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved flexibility by allowing certain view rendering methods to accept a request parameter that can be null.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->