### PR TITLE
fix: correct HTML syntax in empty comment translation

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -300,7 +300,7 @@
 			</trans-unit>
 			<trans-unit id="comment.empty">
 				<source/>
-				<target><![CDATA[Aktuell gibt es keine Kommentare. Du möchtest vielleicht ein <a data-new-comment-uri="%s" data-table="%s" data-id="%s>neuen Kommentar</a> erstellen?]]></target>
+				<target><![CDATA[Aktuell gibt es keine Kommentare. Du möchtest vielleicht ein <a data-new-comment-uri="%s" data-table="%s" data-id="%s">neuen Kommentar</a> erstellen?]]></target>
 			</trans-unit>
 
 			<trans-unit id="assignee.selection.label">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected German localization for the empty comments message by fixing anchor tag markup, ensuring the “neuen Kommentar” link renders and functions correctly.
  * Improves visual appearance and clickability of the link in the German interface without changing the underlying text content.
  * No changes to functionality outside of the corrected display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->