### PR TITLE
fix: improve assignee selection logic by refining user query conditions

### DIFF
--- a/Classes/Domain/Repository/BackendUserRepository.php
+++ b/Classes/Domain/Repository/BackendUserRepository.php
@@ -67,16 +67,18 @@ class BackendUserRepository
                     $queryBuilder->expr()->neq('be_users.usergroup', $queryBuilder->createNamedParameter('')),
                     $queryBuilder->expr()->like(
                         'bg.custom_options',
-                        $queryBuilder->createNamedParameter('%,tx_ximatypo3contentplanner:content-status,%')
+                        $queryBuilder->createNamedParameter('%tx_ximatypo3contentplanner:content-status%')
                     )
                 )->__toString()
             )
             ->where(
-                $queryBuilder->expr()->or(
-                    $queryBuilder->expr()->eq('be_users.admin', 1),
-                    $queryBuilder->expr()->neq('be_users.deleted', 0),
-                    $queryBuilder->expr()->neq('be_users.disable', 0),
-                    $queryBuilder->expr()->isNotNull('bg.uid')
+                $queryBuilder->expr()->and(
+                    $queryBuilder->expr()->eq('be_users.deleted', 0),
+                    $queryBuilder->expr()->eq('be_users.disable', 0),
+                    $queryBuilder->expr()->or(
+                        $queryBuilder->expr()->eq('be_users.admin', 1),
+                        $queryBuilder->expr()->isNotNull('bg.uid'),
+                    ),
                 )
             )
             ->orderBy('be_users.username')

--- a/Classes/Utility/ExtensionUtility.php
+++ b/Classes/Utility/ExtensionUtility.php
@@ -80,11 +80,11 @@ class ExtensionUtility
                         ],
                         'foreign_table' => 'be_users',
                         'foreign_table_where' =>
-                            'admin=1 OR FIND_IN_SET(uid, (
+                            '(admin=1 AND disable=0 AND deleted=0) OR FIND_IN_SET(uid, (
                                 SELECT GROUP_CONCAT(be_users.uid)
                                 FROM be_users
                                 JOIN be_groups ON FIND_IN_SET(be_groups.uid, be_users.usergroup)
-                                WHERE FIND_IN_SET(\'tx_ximatypo3contentplanner:content-status\', be_groups.custom_options)
+                                WHERE FIND_IN_SET(\'tx_ximatypo3contentplanner:content-status\', be_groups.custom_options) AND be_users.disable=0 AND be_users.deleted=0 AND be_groups.deleted=0
                             )) ORDER BY username',
                         'resetSelection' => true,
                         'minitems' => 0,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Assignee selection now shows only active, non-deleted users.
  * Admin users are considered only if active and not deleted.
  * User listings exclude disabled/deleted accounts unless valid group membership applies.
  * Group-based visibility now respects non-deleted groups only.
  * Prevents assigning or suggesting inactive accounts, improving data accuracy and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->