### PR TITLE
fix: correct property name casing for user real name

### DIFF
--- a/Classes/Utility/ContentUtility.php
+++ b/Classes/Utility/ContentUtility.php
@@ -73,17 +73,18 @@ class ContentUtility
             return '';
         }
 
-        if (isset($user['realname']) && $user['realname'] !== '') {
-            return $user['realname'] . ' (' . $user['username'] . ')';
+        if (isset($user['realName']) && $user['realName'] !== '') {
+            return $user['realName'] . ' (' . $user['username'] . ')';
         }
 
         return $user['username'];
     }
 
     /**
-    * @return array<string, mixed>|bool
-    * @Deprecated
-    */
+     * @return array<string, mixed>|bool
+     * @Deprecated
+     * @throws Exception
+     */
     public static function getComment(int $id): array|bool
     {
         if (!(bool)$id) {

--- a/Tests/Unit/Utility/ContentUtilityTest.php
+++ b/Tests/Unit/Utility/ContentUtilityTest.php
@@ -34,11 +34,11 @@ use Xima\XimaTypo3ContentPlanner\Utility\ContentUtility;
  */
 final class ContentUtilityTest extends TestCase
 {
-    public function testGenerateDisplayNameWithRealnameAndUsername(): void
+    public function testGenerateDisplayNameWithrealNameAndUsername(): void
     {
         $user = [
             'username' => 'john.doe',
-            'realname' => 'John Doe',
+            'realName' => 'John Doe',
         ];
 
         $result = ContentUtility::generateDisplayName($user);
@@ -57,11 +57,11 @@ final class ContentUtilityTest extends TestCase
         self::assertSame('jane.smith', $result);
     }
 
-    public function testGenerateDisplayNameWithEmptyRealname(): void
+    public function testGenerateDisplayNameWithEmptyrealName(): void
     {
         $user = [
             'username' => 'test.user',
-            'realname' => '',
+            'realName' => '',
         ];
 
         $result = ContentUtility::generateDisplayName($user);
@@ -72,7 +72,7 @@ final class ContentUtilityTest extends TestCase
     public function testGenerateDisplayNameWithoutUsername(): void
     {
         $user = [
-            'realname' => 'Test User',
+            'realName' => 'Test User',
         ];
 
         $result = ContentUtility::generateDisplayName($user);
@@ -89,11 +89,11 @@ final class ContentUtilityTest extends TestCase
         self::assertSame('', $result);
     }
 
-    public function testGenerateDisplayNameWithNullRealname(): void
+    public function testGenerateDisplayNameWithNullrealName(): void
     {
         $user = [
             'username' => 'test.user',
-            'realname' => null,
+            'realName' => null,
         ];
 
         $result = ContentUtility::generateDisplayName($user);
@@ -105,7 +105,7 @@ final class ContentUtilityTest extends TestCase
     {
         $user = [
             'username' => 'user123',
-            'realname' => '123 Test User',
+            'realName' => '123 Test User',
         ];
 
         $result = ContentUtility::generateDisplayName($user);
@@ -117,7 +117,7 @@ final class ContentUtilityTest extends TestCase
     {
         $user = [
             'username' => 'test.user@example.com',
-            'realname' => 'Test User (Admin)',
+            'realName' => 'Test User (Admin)',
         ];
 
         $result = ContentUtility::generateDisplayName($user);
@@ -125,11 +125,11 @@ final class ContentUtilityTest extends TestCase
         self::assertSame('Test User (Admin) (test.user@example.com)', $result);
     }
 
-    public function testGenerateDisplayNameWithRealnameZeroString(): void
+    public function testGenerateDisplayNameWithrealNameZeroString(): void
     {
         $user = [
             'username' => 'test.user',
-            'realname' => '0',
+            'realName' => '0',
         ];
 
         $result = ContentUtility::generateDisplayName($user);
@@ -137,11 +137,11 @@ final class ContentUtilityTest extends TestCase
         self::assertSame('0 (test.user)', $result);
     }
 
-    public function testGenerateDisplayNameWithWhitespaceOnlyRealname(): void
+    public function testGenerateDisplayNameWithWhitespaceOnlyrealName(): void
     {
         $user = [
             'username' => 'test.user',
-            'realname' => '     ',
+            'realName' => '     ',
         ];
 
         $result = ContentUtility::generateDisplayName($user);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Display names now prefer the user’s real name when available, falling back to the username and shown as “Real Name (username)”. This resolves cases where real names were ignored and improves clarity and consistency across profiles, posts, and notifications.
- **Documentation**
  - Updated internal documentation to note a possible exception during comment retrieval; no functional changes for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->