### PR TITLE
fix: handle case when preRecord is not found in StatusChangeManager

### DIFF
--- a/Classes/Manager/StatusChangeManager.php
+++ b/Classes/Manager/StatusChangeManager.php
@@ -74,6 +74,10 @@ class StatusChangeManager
 
         $preRecord = $this->recordRepository->findByUid($table, $id);
 
+        if ($preRecord === false) {
+            return;
+        }
+
         // auto assign user if status is initially set
         if ((!array_key_exists('tx_ximatypo3contentplanner_assignee', $incomingFieldArray) || $incomingFieldArray['tx_ximatypo3contentplanner_assignee'] === null)
             && $incomingFieldArray['tx_ximatypo3contentplanner_status'] !== null


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents errors and unintended behavior when a previous record is unavailable during status updates.
  * Stops accidental auto-assignment and incorrect status-change handling in edge cases with missing history.
  * Improves workflow stability by only applying status-related logic when valid prior data exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->