### PR TITLE
fix: improve user permission retrieval for backend users

### DIFF
--- a/Classes/Domain/Repository/BackendUserRepository.php
+++ b/Classes/Domain/Repository/BackendUserRepository.php
@@ -56,34 +56,115 @@ class BackendUserRepository
     */
     public function findAllWithPermission(): array|bool
     {
+        // First, get all group UIDs that have the permission (including subgroups recursively)
+        $authorizedGroupUids = $this->getGroupUidsWithPermission('tx_ximatypo3contentplanner:content-status');
+
+        // Build query for users
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('be_users');
-        return $queryBuilder->select('be_users.*')
+        $query = $queryBuilder
+            ->select('be_users.*')
             ->from('be_users')
-            ->leftJoin(
-                'be_users',
-                'be_groups',
-                'bg',
-                $queryBuilder->expr()->and(
-                    $queryBuilder->expr()->neq('be_users.usergroup', $queryBuilder->createNamedParameter('')),
-                    $queryBuilder->expr()->like(
-                        'bg.custom_options',
-                        $queryBuilder->createNamedParameter('%tx_ximatypo3contentplanner:content-status%')
-                    )
-                )->__toString()
-            )
             ->where(
-                $queryBuilder->expr()->and(
-                    $queryBuilder->expr()->eq('be_users.deleted', 0),
-                    $queryBuilder->expr()->eq('be_users.disable', 0),
-                    $queryBuilder->expr()->or(
-                        $queryBuilder->expr()->eq('be_users.admin', 1),
-                        $queryBuilder->expr()->isNotNull('bg.uid'),
-                    ),
-                )
+                $queryBuilder->expr()->eq('be_users.deleted', 0),
+                $queryBuilder->expr()->eq('be_users.disable', 0)
             )
-            ->orderBy('be_users.username')
+            ->orderBy('be_users.username');
+
+        // Add condition: admin users OR users that belong to authorized groups
+        if ($authorizedGroupUids !== []) {
+            $orConditions = [
+                $queryBuilder->expr()->eq('be_users.admin', 1),
+            ];
+
+            // Check if user's usergroup field contains any of the authorized group UIDs
+            foreach ($authorizedGroupUids as $groupUid) {
+                $orConditions[] = $queryBuilder->expr()->inSet('be_users.usergroup', (string)$groupUid);
+            }
+
+            $query->andWhere($queryBuilder->expr()->or(...$orConditions));
+        } else {
+            // Only admin users if no groups have the permission
+            $query->andWhere($queryBuilder->expr()->eq('be_users.admin', 1));
+        }
+
+        return $query->executeQuery()->fetchAllAssociative();
+    }
+
+    /**
+    * Get all group UIDs that have a specific permission (recursively including subgroups).
+    *
+    * @param string $permission The permission to check (e.g., 'tx_ximatypo3contentplanner:content-status')
+    * @return array<int> Array of group UIDs
+    * @throws Exception
+    */
+    private function getGroupUidsWithPermission(string $permission): array
+    {
+        // Get all groups with their permissions and subgroups
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('be_groups');
+        $allGroups = $queryBuilder
+            ->select('uid', 'subgroup', 'custom_options')
+            ->from('be_groups')
+            ->where($queryBuilder->expr()->eq('deleted', 0))
             ->executeQuery()
             ->fetchAllAssociative();
+
+        // Build a map for quick lookup
+        $groupMap = [];
+        foreach ($allGroups as $group) {
+            $groupMap[(int)$group['uid']] = [
+                'custom_options' => $group['custom_options'] ?? '',
+                'subgroups' => ($group['subgroup'] ?? '') !== '' ? array_map('intval', explode(',', (string)$group['subgroup'])) : [],
+            ];
+        }
+
+        // Find all groups that directly have the permission
+        $authorizedGroups = [];
+        foreach ($groupMap as $uid => $data) {
+            if ($this->hasPermission($data['custom_options'], $permission)) {
+                $authorizedGroups[$uid] = true;
+            }
+        }
+
+        // Recursively find parent groups that include authorized subgroups
+        $changed = true;
+        while ($changed) {
+            $changed = false;
+            foreach ($groupMap as $uid => $data) {
+                // Skip if already authorized
+                if (isset($authorizedGroups[$uid])) {
+                    continue;
+                }
+
+                // Check if any subgroup is authorized
+                foreach ($data['subgroups'] as $subgroupUid) {
+                    if (isset($authorizedGroups[$subgroupUid])) {
+                        $authorizedGroups[$uid] = true;
+                        $changed = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        return array_keys($authorizedGroups);
+    }
+
+    /**
+    * Check if a custom_options string contains a specific permission.
+    *
+    * @param string $customOptions The custom_options field value
+    * @param string $permission The permission to check
+    * @return bool
+    */
+    private function hasPermission(string $customOptions, string $permission): bool
+    {
+        if ($customOptions === '') {
+            return false;
+        }
+
+        // custom_options is stored as comma-separated values
+        $options = array_map('trim', explode(',', $customOptions));
+        return in_array($permission, $options, true);
     }
 
     /**

--- a/Classes/Utility/ExtensionUtility.php
+++ b/Classes/Utility/ExtensionUtility.php
@@ -78,14 +78,8 @@ class ExtensionUtility
                                 'value' => null,
                             ],
                         ],
-                        'foreign_table' => 'be_users',
-                        'foreign_table_where' =>
-                            '(admin=1 AND disable=0 AND deleted=0) OR FIND_IN_SET(uid, (
-                                SELECT GROUP_CONCAT(be_users.uid)
-                                FROM be_users
-                                JOIN be_groups ON FIND_IN_SET(be_groups.uid, be_users.usergroup)
-                                WHERE FIND_IN_SET(\'tx_ximatypo3contentplanner:content-status\', be_groups.custom_options) AND be_users.disable=0 AND be_users.deleted=0 AND be_groups.deleted=0
-                            )) ORDER BY username',
+                        'itemsProcFunc' =>
+                            'Xima\XimaTypo3ContentPlanner\Utility\StatusRegistry->getAssignableUsers',
                         'resetSelection' => true,
                         'minitems' => 0,
                         'maxitems' => 1,

--- a/Classes/Utility/StatusRegistry.php
+++ b/Classes/Utility/StatusRegistry.php
@@ -23,8 +23,10 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3ContentPlanner\Utility;
 
+use Doctrine\DBAL\Exception;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Xima\XimaTypo3ContentPlanner\Configuration;
+use Xima\XimaTypo3ContentPlanner\Domain\Repository\BackendUserRepository;
 use Xima\XimaTypo3ContentPlanner\Domain\Repository\StatusRepository;
 
 /**
@@ -76,6 +78,37 @@ class StatusRegistry
                 $color,
                 "color-$color",
             ];
+        }
+    }
+
+    /**
+     * Get backend users with Content Planner permission.
+     *
+     * @param array<string, mixed> $config
+     * @throws Exception
+     */
+    public function getAssignableUsers(array &$config): void
+    {
+        $backendUserRepository = GeneralUtility::makeInstance(BackendUserRepository::class);
+
+        try {
+            $users = $backendUserRepository->findAllWithPermission();
+
+            if (is_array($users)) {
+                foreach ($users as $user) {
+                    $label = $user['username'];
+                    if (($user['realName'] ?? '') !== '') {
+                        $label = $user['realName'] . ' (' . $user['username'] . ')';
+                    }
+
+                    $config['items'][] = [
+                        'label' => $label,
+                        'value' => $user['uid'],
+                    ];
+                }
+            }
+        } catch (\Exception $e) {
+            // In case of error, keep the default items
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Improvements
  * Assignee dropdown now lists only eligible backend users based on permissions, including inherited subgroup permissions; administrators are always available.
  * User labels include real names (when available) for clearer identification.
  * More reliable and consistent loading of assignable users; gracefully falls back without errors if data cannot be fetched.
  * Results are now consistent across the backend wherever the assignee field is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->