### PR TITLE
fix: clarify description for extension version in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,7 @@ body:
     id: extension-version
     attributes:
       label: Extension version
-      description: What version of EXT:solver are you using?
+      description: What version of the extension are you using?
       placeholder: 'e.g. 0.1.0'
     validations:
       required: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the bug report template to ask for the “extension” version instead of “EXT:solver,” improving clarity for users when reporting issues and reducing confusion.
  * Refines the wording to make version reporting more intuitive, helping streamline issue submissions and ensuring more accurate information is provided by reporters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->