### PR TITLE
fix: update record validation checks in AbstractSelectionService

### DIFF
--- a/Classes/Service/SelectionBuilder/AbstractSelectionService.php
+++ b/Classes/Service/SelectionBuilder/AbstractSelectionService.php
@@ -279,7 +279,7 @@ class AbstractSelectionService
      */
     private function addStatusResetSection(array &$selectionEntriesToAdd, array|bool|null $record, string $table, int $uid): void
     {
-        if (null === $record || (null !== $record['tx_ximatypo3contentplanner_status'] && 0 !== $record['tx_ximatypo3contentplanner_status'])) {
+        if (!is_array($record) || (null !== $record['tx_ximatypo3contentplanner_status'] && 0 !== $record['tx_ximatypo3contentplanner_status'])) {
             if ([] !== $selectionEntriesToAdd) {
                 $this->addDividerItemToSelection($selectionEntriesToAdd);
             }
@@ -295,7 +295,7 @@ class AbstractSelectionService
      */
     private function addAdditionalActionsSection(array &$selectionEntriesToAdd, array|bool|null $record, string $table, int $uid): void
     {
-        if (null === $record || null === $this->getCurrentStatus($record)) {
+        if (!is_array($record) || null === $this->getCurrentStatus($record)) {
             return;
         }
 


### PR DESCRIPTION
Fix the following error with the page tree context menu on the root page.

```
Uncaught TYPO3 Exception: #1476107295: PHP Warning: Trying to access array offset on false in /var/www/html/vendor/xima/xima-typo3-content-planner/Classes/Service/SelectionBuilder/AbstractSelectionService.php line 282
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved record validation to ensure consistent handling of non-standard record formats, providing more reliable display of status reset options and additional action items throughout the interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->