### PR TITLE
fix: adjust priority of StatusItemProvider to ensure correct execution order

### DIFF
--- a/Classes/Backend/ContextMenu/ItemProviders/StatusItemProvider.php
+++ b/Classes/Backend/ContextMenu/ItemProviders/StatusItemProvider.php
@@ -81,9 +81,14 @@ class StatusItemProvider extends AbstractProvider
         return ExtensionUtility::isRegisteredRecordTable($this->table) && '' !== $this->identifier;
     }
 
+    /**
+     * Very low priority ensures this provider runs last, after all standard items exist.
+     * Higher priority = executed first. Using near-minimum value to avoid conflicts
+     * with other extensions that might use arbitrary priority values.
+     */
     public function getPriority(): int
     {
-        return 73;
+        return 17;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"ext-libxml": "*",
 		"psr/http-message": "^1.0 || ^2.0",
 		"psr/http-server-handler": "^1.0.2",
-        "psr/http-server-middleware": "^1.0.2",
+		"psr/http-server-middleware": "^1.0.2",
 		"symfony/console": "^7.0 || ^8.0",
 		"typo3/cms-backend": "^13.4 || ^14.0",
 		"typo3/cms-beuser": "^13.4 || ^14.0",


### PR DESCRIPTION
Fixes #179 

Related to #156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Lowered the execution priority of status menu item processing so it runs after standard items, reducing potential ordering conflicts with extensions.

* **Style**
  * Minor whitespace/formatting adjustment in dependency declarations (no functional change).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->