### PR TITLE
fix: remove comments field from TCA configuration in ExtensionUtility

### DIFF
--- a/Classes/Controller/ProxyController.php
+++ b/Classes/Controller/ProxyController.php
@@ -135,6 +135,8 @@ class ProxyController extends ActionController
         ],
     ];
 
+    public function __construct(private readonly FlashMessageService $flashMessageService) {}
+
     public function messageAction(ServerRequestInterface $request): ResponseInterface
     {
         $messagePath = $request->getQueryParams()['message'] ?? null;
@@ -149,7 +151,7 @@ class ProxyController extends ActionController
                 return new JsonResponse(['error' => 'Invalid message path'], 400);
             }
 
-            $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
+            $flashMessageService = $this->flashMessageService;
             $notificationQueue = $flashMessageService->getMessageQueueByIdentifier(
                 FlashMessageQueue::NOTIFICATION_QUEUE,
             );

--- a/Classes/Domain/Model/Dto/HistoryItem.php
+++ b/Classes/Domain/Model/Dto/HistoryItem.php
@@ -43,6 +43,13 @@ final class HistoryItem
     /** @var array<string, mixed>|bool|null */
     public array|bool|null $relatedRecord = [];
 
+    private readonly IconFactory $iconFactory;
+
+    public function __construct()
+    {
+        $this->iconFactory = GeneralUtility::makeInstance(IconFactory::class);
+    }
+
     /**
      * @param array<string, mixed> $sysHistoryRow
      */
@@ -148,7 +155,7 @@ final class HistoryItem
 
     public function getChangeTypeIcon(): string
     {
-        $iconFactory = GeneralUtility::makeInstance(IconFactory::class);
+        $iconFactory = $this->iconFactory;
         switch ($this->data['tablename']) {
             case Configuration::TABLE_COMMENT:
                 return IconUtility::getIconByIdentifier('actions-comment');

--- a/Classes/Domain/Model/Dto/StatusItem.php
+++ b/Classes/Domain/Model/Dto/StatusItem.php
@@ -43,6 +43,15 @@ final class StatusItem
 
     private ?CommentRepository $commentRepository = null;
 
+    private readonly IconFactory $iconFactory;
+    private readonly SiteFinder $siteFinder;
+
+    public function __construct()
+    {
+        $this->iconFactory = GeneralUtility::makeInstance(IconFactory::class);
+        $this->siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
+    }
+
     /**
      * @param array<string, mixed> $row
      */
@@ -123,12 +132,12 @@ final class StatusItem
 
     public function getSite(): ?string
     {
-        $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
+        $siteFinder = $this->siteFinder;
         if (count($siteFinder->getAllSites()) <= 1) {
             return null;
         }
         $site = $siteFinder->getSiteByPageId((int) (('pages' === $this->data['tablename']) ? $this->data['uid'] : $this->data['pid']));
-        $iconFactory = GeneralUtility::makeInstance(IconFactory::class);
+        $iconFactory = $this->iconFactory;
         $icon = $iconFactory->getIcon('apps-pagetree-folder-root', IconUtility::getDefaultIconSize());
 
         /* @phpstan-ignore-next-line */

--- a/Classes/EventListener/AfterFileStorageTreeItemsPreparedListener.php
+++ b/Classes/EventListener/AfterFileStorageTreeItemsPreparedListener.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3ContentPlanner\EventListener;
 
+use Doctrine\DBAL\Exception;
 use TYPO3\CMS\Backend\Controller\Event\AfterFileStorageTreeItemsPreparedEvent;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
 use TYPO3\CMS\Core\Resource\Folder;
@@ -42,6 +43,7 @@ final readonly class AfterFileStorageTreeItemsPreparedListener
 
     /**
      * @param object $event AfterFileStorageTreeItemsPreparedEvent (TYPO3 v14+)
+     * @throws Exception
      */
     public function __invoke(object $event): void
     {

--- a/Classes/EventListener/AfterFileStorageTreeItemsPreparedListener.php
+++ b/Classes/EventListener/AfterFileStorageTreeItemsPreparedListener.php
@@ -43,6 +43,7 @@ final readonly class AfterFileStorageTreeItemsPreparedListener
 
     /**
      * @param object $event AfterFileStorageTreeItemsPreparedEvent (TYPO3 v14+)
+     *
      * @throws Exception
      */
     public function __invoke(object $event): void

--- a/Classes/Utility/ExtensionUtility.php
+++ b/Classes/Utility/ExtensionUtility.php
@@ -74,6 +74,22 @@ class ExtensionUtility
                         'nullable' => true,
                     ],
                 ],
+                Configuration::FIELD_COMMENTS => [
+                    'label' => 'LLL:EXT:'.Configuration::EXT_KEY.
+                        '/Resources/Private/Language/locallang_db.xlf:pages.tx_ximatypo3contentplanner_comments',
+                    'config' => [
+                        'foreign_field' => 'foreign_uid',
+                        'foreign_default_sortby' => 'crdate DESC',
+                        'foreign_table' => Configuration::TABLE_COMMENT,
+                        'foreign_table_field' => 'foreign_table',
+                        'type' => 'inline',
+                        'appearance' => [
+                            'collapseAll' => true,
+                            'expandSingle' => true,
+                            'useSortable' => false,
+                        ],
+                    ],
+                ],
             ],
         );
 

--- a/Classes/Utility/ExtensionUtility.php
+++ b/Classes/Utility/ExtensionUtility.php
@@ -74,27 +74,11 @@ class ExtensionUtility
                         'nullable' => true,
                     ],
                 ],
-                Configuration::FIELD_COMMENTS => [
-                    'label' => 'LLL:EXT:'.Configuration::EXT_KEY.
-                        '/Resources/Private/Language/locallang_db.xlf:pages.tx_ximatypo3contentplanner_comments',
-                    'config' => [
-                        'foreign_field' => 'foreign_uid',
-                        'foreign_default_sortby' => 'crdate',
-                        'foreign_table' => Configuration::TABLE_COMMENT,
-                        'foreign_table_field' => 'foreign_table',
-                        'type' => 'inline',
-                        'appearance' => [
-                            'collapseAll' => true,
-                            'expandSingle' => true,
-                            'useSortable' => false,
-                        ],
-                    ],
-                ],
             ],
         );
 
         $GLOBALS['TCA'][$table]['palettes']['tx_ximatypo3contentplanner'] = [
-            'showitem' => 'tx_ximatypo3contentplanner_status,tx_ximatypo3contentplanner_assignee,--linebreak--,tx_ximatypo3contentplanner_comments',
+            'showitem' => 'tx_ximatypo3contentplanner_status,tx_ximatypo3contentplanner_assignee',
         ];
 
         ExtensionManagementUtility::addToAllTCAtypes(


### PR DESCRIPTION
Relates to #185

The editing functions relating to comments, assigned editors, and status will gradually disappear from the page properties, as these can be configured via the page header. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the comments field from the Content Planner tab; the tab now shows only status and assignee.
* **Improvements**
  * Updated the default sort order for comments to show newest entries first.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->