### PR TITLE
fix: update comment sorting to use creation date instead of timestamp

### DIFF
--- a/Classes/Widgets/Provider/ContentCommentDataProvider.php
+++ b/Classes/Widgets/Provider/ContentCommentDataProvider.php
@@ -43,13 +43,13 @@ class ContentCommentDataProvider implements ListDataProviderInterface
                 'c.uid',
                 'c.content',
                 'c.author',
-                'c.tstamp',
+                'c.crdate',
                 'c.foreign_uid',
                 'c.foreign_table',
             )
             ->from(Configuration::TABLE_COMMENT, 'c')
             ->setMaxResults(10)
-            ->orderBy('tstamp', 'DESC');
+            ->orderBy('crdate', 'DESC');
 
         $items = [];
         $results = $query->executeQuery()

--- a/Resources/Private/Templates/Backend/Widgets/ContentCommentList.html
+++ b/Resources/Private/Templates/Backend/Widgets/ContentCommentList.html
@@ -14,7 +14,7 @@
                             <div class="d-flex flex-row justify-content-between">
                                 <div>
                                     <strong>{record.authorName}</strong>
-                                    <small>{record.data.tstamp -> f:format.date(format:'d.m.Y  H:i')}</small>
+                                    <small>{record.data.crdate -> f:format.date(format:'d.m.Y  H:i')}</small>
                                 </div>
                                 <small>
                                     <core:icon identifier="{record.statusIcon}" size="small" title="{record.status}"/>


### PR DESCRIPTION
Fixes #185 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Comments are now sorted by creation date instead of last modification timestamp. The displayed date reflects when the comment was originally created, improving chronological accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->