### PR TITLE
feat: replace widget filter with modal and add new filter options

### DIFF
--- a/Classes/Controller/RecordController.php
+++ b/Classes/Controller/RecordController.php
@@ -51,8 +51,9 @@ class RecordController extends ActionController
         $assignee = array_key_exists('assignee', $request->getQueryParams()) ? (int) $request->getQueryParams()['assignee'] : null;
         $todo = array_key_exists('todo', $request->getQueryParams()) ? (bool) $request->getQueryParams()['todo'] : false;
         $type = array_key_exists('type', $request->getQueryParams()) ? $request->getQueryParams()['type'] : null;
+        $openComments = array_key_exists('openComments', $request->getQueryParams()) ? (bool) $request->getQueryParams()['openComments'] : false;
 
-        $records = $this->recordRepository->findAllByFilter($search, $status, assignee: $assignee, type: $type, todo: $todo);
+        $records = $this->recordRepository->findAllByFilter($search, $status, assignee: $assignee, type: $type, todo: $todo, openComments: $openComments);
         $result = [];
         foreach ($records as $record) {
             $result[] = StatusItem::create($record)->toArray();

--- a/Classes/Widgets/ContentStatusWidget.php
+++ b/Classes/Widgets/ContentStatusWidget.php
@@ -48,6 +48,7 @@ class ContentStatusWidget extends AbstractWidget
                 'options' => $this->options,
                 'icon' => $icon,
                 'currentBackendUser' => $assignee,
+                'backendUserId' => $GLOBALS['BE_USER']->getUserId(),
                 'todo' => $todoInfo,
                 'mode' => $mode,
                 'filter' => $filterValues,

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -315,6 +315,26 @@
 				<source/>
 				<target>Zurücksetzen</target>
 			</trans-unit>
+			<trans-unit id="filter.button">
+				<source/>
+				<target>Filter</target>
+			</trans-unit>
+			<trans-unit id="filter.modal.title">
+				<source/>
+				<target>Datensätze filtern</target>
+			</trans-unit>
+			<trans-unit id="filter.modal.apply">
+				<source/>
+				<target>Anwenden</target>
+			</trans-unit>
+			<trans-unit id="filter.openComments">
+				<source/>
+				<target>Offene Kommentare</target>
+			</trans-unit>
+			<trans-unit id="filter.openTodos">
+				<source/>
+				<target>Offene ToDos</target>
+			</trans-unit>
 
 			<trans-unit id="comment.edited">
 				<source/>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -179,6 +179,21 @@
 			<trans-unit id="filter.reset">
 				<source>Reset</source>
 			</trans-unit>
+			<trans-unit id="filter.button">
+				<source>Filter</source>
+			</trans-unit>
+			<trans-unit id="filter.modal.title">
+				<source>Filter records</source>
+			</trans-unit>
+			<trans-unit id="filter.modal.apply">
+				<source>Apply</source>
+			</trans-unit>
+			<trans-unit id="filter.openComments">
+				<source>Open comments</source>
+			</trans-unit>
+			<trans-unit id="filter.openTodos">
+				<source>Open TODOs</source>
+			</trans-unit>
 
 			<trans-unit id="comment.edited">
 				<source>edited</source>

--- a/Resources/Private/Partials/WidgetFilter.html
+++ b/Resources/Private/Partials/WidgetFilter.html
@@ -17,56 +17,13 @@
 
             </div>
         </div>
-        <div class="form-group">
-            <label for="status" class="form-label">Status</label>
-            <div class="input-group">
-                <button type="submit" class="btn btn-default disabled">
-                                <span class="visually-hidden"><f:translate
-                                    id="LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.title.search"/></span>
-                    <core:icon identifier="flag-gray"/>
-                </button>
-                <select name="status" id="status" class="form-select">
-                    <option value="">-</option>
-                    <f:for each="{filter.status}" as="status">
-                        <option value="{status.uid}">{status.title}</option>
-                    </f:for>
-                </select>
-            </div>
+        <div class="form-group align-self-end">
+            <button class="btn btn-default content-planner-widget__filter-modal-trigger" type="button">
+                <core:icon identifier="actions-filter" size="small"/>
+                <span class="content-planner-widget__filter-label"><f:translate key="LLL:EXT:xima_typo3_content_planner/Resources/Private/Language/locallang.xlf:filter.button" default="Filter"/></span>
+                <span class="badge badge-pill badge-warning content-planner-widget__filter-badge" hidden></span>
+            </button>
         </div>
-        <div class="form-group">
-            <label for="users" class="form-label">Assignee</label>
-            <div class="input-group">
-                <button type="submit" class="btn btn-default disabled">
-                                <span class="visually-hidden"><f:translate
-                                    id="LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.title.search"/></span>
-                    <core:icon identifier="actions-user"/>
-                </button>
-                <select name="assignee" id="users" class="form-select">
-                    <option value="">-</option>
-                    <f:for each="{filter.users}" as="user">
-                        <option value="{user.uid}">{user.username}</option>
-                    </f:for>
-                </select>
-            </div>
-        </div>
-        <f:if condition="{filter.types}">
-            <div class="form-group">
-                <label for="type" class="form-label">Type</label>
-                <div class="input-group">
-                    <button type="submit" class="btn btn-default disabled">
-                                <span class="visually-hidden"><f:translate
-                                    id="LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.title.search"/></span>
-                        <core:icon identifier="actions-extension"/>
-                    </button>
-                    <select name="type" id="type" class="form-select">
-                        <option value="">-</option>
-                        <f:for each="{filter.types}" as="type">
-                            <option value="{type.value}">{type.label}</option>
-                        </f:for>
-                    </select>
-                </div>
-            </div>
-        </f:if>
         <div class="form-group align-self-end">
             <button class="btn btn-default content-planner-widget__filter-reset" type="reset">
                 <core:icon identifier="actions-close" size="small"/>
@@ -76,4 +33,52 @@
     </div>
 </form>
 
+<template class="content-planner-widget__filter-modal-content">
+    <div class="content-planner-widget__filter-modal-form">
+        <div class="form-group mb-3">
+            <label for="status" class="form-label">Status</label>
+            <select name="status" id="status" class="form-select">
+                <option value="">-</option>
+                <f:for each="{filter.status}" as="status">
+                    <option value="{status.uid}">{status.title}</option>
+                </f:for>
+            </select>
+        </div>
+        <div class="form-group mb-3">
+            <label for="users" class="form-label"><f:translate key="widgets.contentPlanner.header.assignee" extensionName="XimaTypo3ContentPlanner" default="Assignee"/></label>
+            <div class="input-group">
+                <select name="assignee" id="users" class="form-select">
+                    <option value="">-</option>
+                    <f:for each="{filter.users}" as="user">
+                        <option value="{user.uid}">{user.username}</option>
+                    </f:for>
+                </select>
+                <button type="button" class="btn btn-default content-planner-widget__filter-assign-to-me" data-backend-user-id="{backendUserId}" title="{f:translate(key: 'header.assignToMe', extensionName: 'XimaTypo3ContentPlanner', default: 'Assigned to me')}">
+                    <core:icon identifier="actions-assign-to-me" size="small"/>
+                </button>
+            </div>
+        </div>
+        <f:if condition="{filter.types}">
+            <div class="form-group mb-3">
+                <label for="type" class="form-label">Type</label>
+                <select name="type" id="type" class="form-select">
+                    <option value="">-</option>
+                    <f:for each="{filter.types}" as="type">
+                        <option value="{type.value}">{type.label}</option>
+                    </f:for>
+                </select>
+            </div>
+        </f:if>
+        <div class="form-check mb-2">
+            <input class="form-check-input" type="checkbox" name="openComments" id="openComments" value="1">
+            <label class="form-check-label" for="openComments"><f:translate key="LLL:EXT:xima_typo3_content_planner/Resources/Private/Language/locallang.xlf:filter.openComments" default="Open comments"/></label>
+        </div>
+        <div class="form-check mb-2">
+            <input class="form-check-input" type="checkbox" name="todo" id="todo" value="1">
+            <label class="form-check-label" for="todo"><f:translate key="LLL:EXT:xima_typo3_content_planner/Resources/Private/Language/locallang.xlf:filter.openTodos" default="Open TODOs"/></label>
+        </div>
+    </div>
+</template>
+
 </div>
+</html>

--- a/Resources/Private/Partials/WidgetFilter.html
+++ b/Resources/Private/Partials/WidgetFilter.html
@@ -36,7 +36,7 @@
 <template class="content-planner-widget__filter-modal-content">
     <div class="content-planner-widget__filter-modal-form">
         <div class="form-group mb-3">
-            <label for="status" class="form-label">Status</label>
+            <label for="status" class="form-label"><f:translate key="widgets.contentPlanner.header.flag" extensionName="XimaTypo3ContentPlanner" default="Status"/></label>
             <select name="status" id="status" class="form-select">
                 <option value="">-</option>
                 <f:for each="{filter.status}" as="status">
@@ -53,14 +53,14 @@
                         <option value="{user.uid}">{user.username}</option>
                     </f:for>
                 </select>
-                <button type="button" class="btn btn-default content-planner-widget__filter-assign-to-me" data-backend-user-id="{backendUserId}" title="{f:translate(key: 'header.assignToMe', extensionName: 'XimaTypo3ContentPlanner', default: 'Assigned to me')}">
+                <button type="button" class="btn btn-default content-planner-widget__filter-assign-to-me" data-backend-user-id="{backendUserId}" title="{f:translate(key: 'header.assignToMe', extensionName: 'XimaTypo3ContentPlanner', default: 'Assign to me')}">
                     <core:icon identifier="actions-assign-to-me" size="small"/>
                 </button>
             </div>
         </div>
         <f:if condition="{filter.types}">
             <div class="form-group mb-3">
-                <label for="type" class="form-label">Type</label>
+                <label for="type" class="form-label"><f:translate key="widgets.configurable.setting.recordType.label" extensionName="XimaTypo3ContentPlanner" default="Record Type"/></label>
                 <select name="type" id="type" class="form-select">
                     <option value="">-</option>
                     <f:for each="{filter.types}" as="type">

--- a/Resources/Public/Css/Widgets.css
+++ b/Resources/Public/Css/Widgets.css
@@ -65,24 +65,26 @@
     max-width: 150px;
 }
 
-.content-planner-widget__filter .form-check input[type="radio"] {
-    display: none;
+/* Filter Modal Trigger Button */
+.content-planner-widget__filter-modal-trigger {
+    position: relative;
 }
 
-.content-planner-widget__filter .form-check input[type="radio"]:checked + label {
-    font-weight: bold;
+.content-planner-widget__filter-badge {
+    position: absolute;
+    top: -0.5rem;
+    inset-inline-end: -0.5rem;
+    z-index: 4;
 }
 
-.content-planner-widget__filter .form-check label {
-    padding: 0.5rem 1rem;
-    border: 1px solid #ccc;
-    border-radius: 2rem;
-    margin-top: -10px;
-    cursor: pointer;
+/* Filter Modal Form */
+.content-planner-widget__filter-modal-form .form-label {
+    font-weight: 600;
+    margin-bottom: 0.25rem;
 }
 
-.content-planner-widget__filter .form-check label:hover {
-    background-color: #f5f5f5;
+.content-planner-widget__filter-modal-form .form-select {
+    width: 100%;
 }
 
 /* Table Wrapper */


### PR DESCRIPTION
## Summary

- Replace inline filter dropdowns (status, assignee, type) with a single filter button that opens a TYPO3 modal, solving responsiveness issues in narrow widgets
- Add open comments and open TODOs as new filter options (checkboxes in modal)
- Add "Assign to me" shortcut button next to the assignee dropdown in the filter modal
- Persist filter state in TYPO3 Backend User Configuration (UC) via `@typo3/backend/storage/persistent.js`
- Extract shared comment subquery base in repository to reduce duplication

![filter](https://github.com/user-attachments/assets/5f4e48c8-3dfe-41d8-898c-ad9da1d2286f)

## Changes

- `Resources/Private/Partials/WidgetFilter.html` - Inline dropdowns replaced with search + filter button + modal template
- `Resources/Public/JavaScript/filter-status.js` - Modal logic, UC persistence, assign-to-me shortcut, checkbox support
- `Resources/Public/Css/Widgets.css` - Badge positioning, modal form styles, removed obsolete radio styles
- `Classes/Controller/RecordController.php` - New `openComments` query parameter
- `Classes/Domain/Repository/RecordRepository.php` - Open comments filter subquery, DRY refactor of comment subquery base
- `Classes/Widgets/ContentStatusWidget.php` - Pass `backendUserId` to filter template
- `Resources/Private/Language/locallang.xlf` - New labels (filter button, modal title, apply, open comments, open TODOs)
- `Resources/Private/Language/de.locallang.xlf` - German translations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter modal for improved record filtering UI.
  * "Open comments" and "Open TODOs" filter options.
  * "Assign to me" quick action in the filter.
  * Filter preferences persist across sessions and a badge shows active filters.

* **Localization**
  * Added German and default translations for new filter UI labels.

* **Style**
  * Updated widget styles to support modal-based filter UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->