### PR TITLE
feat: redesign dashboard comment widget with compact layout

### DIFF
--- a/Resources/Private/Templates/Backend/Widgets/ContentCommentList.html
+++ b/Resources/Private/Templates/Backend/Widgets/ContentCommentList.html
@@ -7,24 +7,22 @@
         <f:then>
             <f:for each="{records}" as="record">
                 <f:if condition="{record.relatedRecord}">
-                    <div class="d-flex content-planner-comment">
-                        <be:avatar backendUser="{record.data.author}" size="40"
-                                showIcon="true"/>
-                        <div class="d-flex flex-column flex-grow-1">
-                            <div class="d-flex flex-row justify-content-between">
-                                <div>
-                                    <strong>{record.authorName}</strong>
-                                    <small>{record.data.crdate -> f:format.date(format:'d.m.Y  H:i')}</small>
-                                </div>
-                                <small>
-                                    <core:icon identifier="{record.statusIcon}" size="small" title="{record.status}"/>
-                                    <a href="{record.recordLink}">
-                                        {record.title}
-                                    </a>
-                                </small>
-                            </div>
-                            <div class="content-planner-comment__text">{record.data.content -> f:format.raw()}</div>
+                    <div class="content-planner-comment">
+                        <div class="content-planner-comment__header">
+                            <span class="content-planner-comment__meta">
+                                <be:avatar backendUser="{record.data.author}" size="16" showIcon="false"/>
+                                <strong>{record.authorName}</strong>
+                                <small title="{record.data.crdate -> f:format.date(format:'d.m.Y H:i')}">{record.timeAgo}</small>
+                            </span>
+                            <small class="content-planner-comment__record">
+                                <core:icon identifier="{record.statusIcon}" size="small" title="{record.status}"/>
+                                <a href="{record.shareUri}" title="{record.title}">
+                                    {record.title}
+                                </a>
+                            </small>
                         </div>
+                        <a href="{record.shareUri}"
+                           class="content-planner-comment__text content-planner-comment__text--widget">{record.data.content -> f:format.raw()}</a>
                     </div>
                 </f:if>
             </f:for>

--- a/Resources/Private/Templates/Backend/Widgets/ContentCommentList.html
+++ b/Resources/Private/Templates/Backend/Widgets/ContentCommentList.html
@@ -22,7 +22,7 @@
                             </small>
                         </div>
                         <a href="{record.shareUri}"
-                           class="content-planner-comment__text content-planner-comment__text--widget">{record.data.content -> f:format.raw()}</a>
+                           class="content-planner-comment__text content-planner-comment__text--widget">{record.data.content -> f:format.crop(maxCharacters: 150, append: '…', respectHtml: true) -> f:format.raw()}</a>
                     </div>
                 </f:if>
             </f:for>

--- a/Resources/Public/Css/Comments.css
+++ b/Resources/Public/Css/Comments.css
@@ -14,7 +14,10 @@
    ========================================================================== */
 
 .content-planner-comment {
+    /* Padding + negative margin for highlight animation breathing room */
+    padding: 0.75rem;
     padding-bottom: 2rem;
+    margin: 0 -0.75rem;
     gap: 1rem;
     container-name: comment;
     container-type: inline-size;

--- a/Resources/Public/Css/Comments.css
+++ b/Resources/Public/Css/Comments.css
@@ -15,8 +15,7 @@
 
 .content-planner-comment {
     /* Padding + negative margin for highlight animation breathing room */
-    padding: 0.75rem;
-    padding-bottom: 2rem;
+    padding: 0.75rem 0.75rem 2rem;
     margin: 0 -0.75rem;
     gap: 1rem;
     container-name: comment;

--- a/Resources/Public/Css/Widgets.css
+++ b/Resources/Public/Css/Widgets.css
@@ -191,6 +191,7 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     text-align: end;
+    min-width: 0;
 }
 
 /* Comment Text (Widget) */
@@ -201,12 +202,12 @@
     padding: 0.75rem;
     color: inherit;
     text-decoration: none;
+    transition: background-color 0.15s ease;
 }
 
 .content-planner-comment__text--widget:hover {
     text-decoration: none;
     background-color: rgba(125, 125, 125, 0.2);
-    transition: background-color 0.15s ease;
 }
 
 

--- a/Resources/Public/Css/Widgets.css
+++ b/Resources/Public/Css/Widgets.css
@@ -196,9 +196,6 @@
 /* Comment Text (Widget) */
 .content-planner-comment__text.content-planner-comment__text--widget {
     display: block;
-    overflow: hidden;
-    max-height: 6em;
-    line-height: 1.5;
     width: 100%;
     margin: 0.25rem 0 0;
     padding: 0.75rem;

--- a/Resources/Public/Css/Widgets.css
+++ b/Resources/Public/Css/Widgets.css
@@ -145,29 +145,73 @@
     margin-right: 0.25rem;
 }
 
-/* Comment List */
-.content-planner-comment {
-    align-items: flex-start;
-    padding: 0.5rem 0;
+/* Comment List (Widget) */
+.content-planner-widget > .content-planner-comment {
+    padding: 1rem;
     border-bottom: 1px solid var(--typo3-list-item-border-color, #e0e0e0);
 }
 
-.content-planner-comment:last-child {
+.content-planner-widget > .content-planner-comment:last-child {
     border-bottom: none;
 }
 
-.content-planner-comment .avatar {
-    flex-shrink: 0;
-    width: 40px;
-    height: 40px;
+/* Comment Header: wraps meta + record link on one line (or two if needed) */
+.content-planner-comment__header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.25rem 0.5rem;
 }
 
-.content-planner-comment .avatar img {
-    width: 40px;
-    height: 40px;
+/* Meta: inline avatar + name + time ago */
+.content-planner-comment__meta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    min-width: 0;
+}
+
+.content-planner-comment__meta .avatar {
+    flex-shrink: 0;
+    width: 16px;
+    height: 16px;
+}
+
+.content-planner-comment__meta .avatar img {
+    width: 16px;
+    height: 16px;
     object-fit: cover;
     border-radius: 50%;
 }
+
+/* Record link: right-aligned, shrinks if needed */
+.content-planner-comment__record {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: end;
+}
+
+/* Comment Text (Widget) */
+.content-planner-comment__text.content-planner-comment__text--widget {
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    width: 100%;
+    margin: 0.25rem 0 0;
+    padding: 0.75rem;
+    color: inherit;
+    text-decoration: none;
+}
+
+.content-planner-comment__text--widget:hover {
+    text-decoration: none;
+    background-color: rgba(125, 125, 125, 0.2);
+    transition: background-color 0.15s ease;
+}
+
 
 /* ==========================================================================
    Widget Modifiers

--- a/Resources/Public/Css/Widgets.css
+++ b/Resources/Public/Css/Widgets.css
@@ -195,10 +195,10 @@
 
 /* Comment Text (Widget) */
 .content-planner-comment__text.content-planner-comment__text--widget {
-    display: -webkit-box;
-    -webkit-line-clamp: 4;
-    -webkit-box-orient: vertical;
+    display: block;
     overflow: hidden;
+    max-height: 6em;
+    line-height: 1.5;
     width: 100%;
     margin: 0.25rem 0 0;
     padding: 0.75rem;


### PR DESCRIPTION
## Summary

- Redesign the "Recent Comments" dashboard widget with a compact, space-efficient layout
- Use share links from the comment-share-link feature to deep-link directly to comments
- Add server-side content cropping for reliable text truncation across TYPO3 v13/v14
- Add breathing room padding for the comment highlight animation

![dashboard-widget-comment-link](https://github.com/user-attachments/assets/79308a2b-0bf7-412d-8801-7d7de44e6ad9)

## Changes

- `Resources/Private/Templates/Backend/Widgets/ContentCommentList.html` - Redesigned template: inline 16px avatar with author name, "time ago" date, right-aligned record link with status icon, full-width clickable comment text using `f:format.crop` for truncation
- `Resources/Public/Css/Widgets.css` - New widget-specific comment styles: flex-wrap header, inline meta, ellipsis record link, full-width clickable comment text with hover effect, separator borders
- `Resources/Public/Css/Comments.css` - Added permanent padding + negative margin to all comments for highlight animation breathing room (prevents layout jump)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned comment list into a compact header-driven layout
  * Clickable, cropped content previews (≈150 chars) with hover interaction for widgets

* **Style**
  * Smaller avatars for a tighter, more compact display
  * Refined spacing, padding, and widget-scoped borders for improved visual hierarchy
  * Hover states and truncation/styling tweaks for clearer readability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->