### PR TITLE
fix: add missing source values to German translation files

### DIFF
--- a/Classes/EventListener/ModifyButtonBarEventListener.php
+++ b/Classes/EventListener/ModifyButtonBarEventListener.php
@@ -241,6 +241,9 @@ final readonly class ModifyButtonBarEventListener
             ));
 
         foreach ($buttonsToAdd as $buttonToAdd) {
+            if (!$buttonToAdd->isValid()) {
+                continue;
+            }
             $dropDownButton->addItem($buttonToAdd);
         }
 

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -4,437 +4,437 @@
 		<header/>
 		<body>
 			<trans-unit id="dashboard.contentPlanner">
-				<source/>
+				<source>Content Planner</source>
 				<target>Content Planner</target>
 			</trans-unit>
 			<trans-unit id="dashboard.contentPlanner.description">
-				<source/>
+				<source>Overview dashboard for content status information</source>
 				<target>Übersichtsdashboard für Inhaltsstatusinformationen</target>
 			</trans-unit>
 			<trans-unit id="widget_group.contentPlanner">
-				<source/>
+				<source>Content Planner</source>
 				<target>Content Planner</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.status.title">
-				<source/>
+				<source>Status</source>
 				<target>Status</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.status.description">
-				<source/>
+				<source>Display all records with content status</source>
 				<target>Alle Datensätze mit Inhaltsstatus anzeigen</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.current.title">
-				<source/>
+				<source>Current Assignee</source>
 				<target>Aktueller Zuständigkeit</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.current.description">
-				<source/>
+				<source>Display all records with your assignment</source>
 				<target>Alle Datensätze mit Ihrer Zuweisung anzeigen</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.todo.title">
-				<source/>
+				<source>ToDo</source>
 				<target>Offene Aufgaben</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.todo.description">
-				<source/>
+				<source>Display all records with open todos in the comments</source>
 				<target>Zeigt alle Datensätze mit offenen Aufgaben in den zugehörigen Kommentaren</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.overview.title">
-				<source/>
+				<source>Overview</source>
 				<target>Übersicht</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.overview.description">
-				<source/>
+				<source>Display a donut chart with the distribution of content status</source>
 				<target>Ein Diagramm mit der Verteilung des Inhaltsstatus anzeigen</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.comment.title">
-				<source/>
+				<source>Recent Comments</source>
 				<target>Neueste Kommentare</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.comment.description">
-				<source/>
+				<source>Display the recent content comments</source>
 				<target>Die neuesten Inhaltskommentare anzeigen</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.update.title">
-				<source/>
+				<source>Recent Updates</source>
 				<target>Neueste Updates</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.update.description">
-				<source/>
+				<source>Display the recent updates according to content status changes</source>
 				<target>Die neuesten Updates hinsichtlich Inhaltsstatusänderungen anzeigen</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.header.flag">
-				<source/>
+				<source>Status</source>
 				<target>Status</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.header.title">
-				<source/>
+				<source>Record</source>
 				<target>Datensatz</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.header.site">
-				<source/>
+				<source>Site</source>
 				<target>Seite</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.header.tstamp">
-				<source/>
+				<source>Changed</source>
 				<target>Geändert</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.header.assignee">
-				<source/>
+				<source>Assignee</source>
 				<target>Zuständigkeit</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.header.author">
-				<source/>
+				<source>Author</source>
 				<target>Autor</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.header.comment">
-				<source/>
+				<source>Comment</source>
 				<target>Kommentar</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.header.comments">
-				<source/>
+				<source>Comments</source>
 				<target>Kommentare</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.header.page">
-				<source/>
+				<source>Page</source>
 				<target>Seite</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.header.user">
-				<source/>
+				<source>User</source>
 				<target>Benutzer</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.header.change">
-				<source/>
+				<source>Change note</source>
 				<target>Änderungshinweis</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.status.assignee">
-				<source/>
+				<source><![CDATA[There are currently <span class="badge">0</span> content planner records assigned to you.]]></source>
 				<target><![CDATA[Aktuell sind dir <span class="badge">0</span> Content Planner Datensätze zugewiesen.]]></target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.status.todo">
-				<source/>
+				<source>There are currently %s open tasks in the comments of all content planner records.</source>
 				<target>Aktuell sind %s offene Aufgaben in den Kommentaren aller Content Planner Datensätze vorhanden.</target>
 			</trans-unit>
 
 			<!-- Configurable Widget Settings -->
 			<trans-unit id="widgets.contentPlanner.configurable.title">
-				<source/>
+				<source>Content Planner (Configurable)</source>
 				<target>Content Planner (Konfigurierbar)</target>
 			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.configurable.description">
-				<source/>
+				<source>Customizable widget to display content status records with configurable filters</source>
 				<target>Anpassbares Widget zur Anzeige von Content-Status-Datensätzen mit konfigurierbaren Filtern</target>
 			</trans-unit>
 			<trans-unit id="widgets.configurable.setting.title.label">
-				<source/>
+				<source>Custom Title</source>
 				<target>Eigener Titel</target>
 			</trans-unit>
 			<trans-unit id="widgets.configurable.setting.title.description">
-				<source/>
+				<source>Optional custom title for the widget (leave empty to use default)</source>
 				<target>Optionaler eigener Titel für das Widget (leer lassen für Standardtitel)</target>
 			</trans-unit>
 			<trans-unit id="widgets.configurable.setting.mode.label">
-				<source/>
+				<source>Display Mode</source>
 				<target>Anzeigemodus</target>
 			</trans-unit>
 			<trans-unit id="widgets.configurable.setting.mode.description">
-				<source/>
+				<source>Choose what kind of records to display</source>
 				<target>Wähle aus, welche Art von Datensätzen angezeigt werden soll</target>
 			</trans-unit>
 			<trans-unit id="widgets.configurable.setting.mode.status">
-				<source/>
+				<source>All Status Records</source>
 				<target>Alle Status-Datensätze</target>
 			</trans-unit>
 			<trans-unit id="widgets.configurable.setting.mode.assignee">
-				<source/>
+				<source>Assigned Records</source>
 				<target>Zugewiesene Datensätze</target>
 			</trans-unit>
 			<trans-unit id="widgets.configurable.setting.mode.todo">
-				<source/>
+				<source>Records with open TODOs</source>
 				<target>Datensätze mit offenen Aufgaben</target>
 			</trans-unit>
 			<trans-unit id="widgets.configurable.setting.status.label">
-				<source/>
+				<source>Status Filter</source>
 				<target>Status-Filter</target>
 			</trans-unit>
 			<trans-unit id="widgets.configurable.setting.status.description">
-				<source/>
+				<source>Filter records by a specific status</source>
 				<target>Datensätze nach einem bestimmten Status filtern</target>
 			</trans-unit>
 			<trans-unit id="widgets.configurable.setting.status.all">
-				<source/>
+				<source>All statuses</source>
 				<target>Alle Status</target>
 			</trans-unit>
 			<trans-unit id="widgets.configurable.setting.assignee.label">
-				<source/>
+				<source>Assignee Filter</source>
 				<target>Zuständigkeits-Filter</target>
 			</trans-unit>
 			<trans-unit id="widgets.configurable.setting.assignee.description">
-				<source/>
+				<source>Filter records by assignee</source>
 				<target>Datensätze nach Zuständigkeit filtern</target>
 			</trans-unit>
 			<trans-unit id="widgets.configurable.setting.assignee.all">
-				<source/>
+				<source>All assignees</source>
 				<target>Alle Zuständigen</target>
 			</trans-unit>
 			<trans-unit id="widgets.configurable.setting.assignee.currentUser">
-				<source/>
+				<source>Current user (me)</source>
 				<target>Aktueller Benutzer</target>
 			</trans-unit>
 			<trans-unit id="widgets.configurable.setting.recordType.label">
-				<source/>
+				<source>Record Type</source>
 				<target>Datensatztyp-Filter</target>
 			</trans-unit>
 			<trans-unit id="widgets.configurable.setting.recordType.description">
-				<source/>
+				<source>Filter records by table type</source>
 				<target>Datensätze nach Typ filtern</target>
 			</trans-unit>
 			<trans-unit id="widgets.configurable.setting.recordType.all">
-				<source/>
+				<source>All record types</source>
 				<target>Alle Datensatztypen</target>
 			</trans-unit>
 
 			<trans-unit id="button.modal.header.comments">
-				<source/>
+				<source>Comments</source>
 				<target>Kommentare</target>
 			</trans-unit>
 			<trans-unit id="button.modal.footer.close">
-				<source/>
+				<source>Cancel</source>
 				<target>Abbrechen</target>
 			</trans-unit>
 			<trans-unit id="button.modal.footer.new">
-				<source/>
+				<source>New</source>
 				<target>Neu</target>
 			</trans-unit>
 			<trans-unit id="button.modal.footer.edit">
-				<source/>
+				<source>Edit</source>
 				<target>Edit</target>
 			</trans-unit>
 			<trans-unit id="button.modal.footer.save">
-				<source/>
+				<source>Save</source>
 				<target>Speichern</target>
 			</trans-unit>
 
 			<!-- header info -->
 			<trans-unit id="header.status">
-				<source/>
+				<source>Status</source>
 				<target>Status</target>
 			</trans-unit>
 			<trans-unit id="header.editStatus">
-				<source/>
+				<source>Edit status properties</source>
 				<target>Status Eigenschaften bearbeiten</target>
 			</trans-unit>
 			<trans-unit id="header.editContentElement">
-				<source/>
-				<target>Inhaltselement ”%s” bearbeiten</target>
+				<source>Edit content element "%s"</source>
+				<target>Inhaltselement "%s" bearbeiten</target>
 			</trans-unit>
 			<trans-unit id="header.assignee">
-				<source/>
+				<source>Current assignee</source>
 				<target>Zuständiger Nutzer</target>
 			</trans-unit>
 			<trans-unit id="header.assignToMe">
-				<source/>
+				<source>Assign to me</source>
 				<target>Mir zuweisen</target>
 			</trans-unit>
 			<trans-unit id="header.unassign">
-				<source/>
+				<source>Unassign</source>
 				<target>Zuweisung aufheben</target>
 			</trans-unit>
 			<trans-unit id="header.unassigned">
-				<source/>
+				<source>-- Not assigned --</source>
 				<target>-- Nicht zugewiesen --</target>
 			</trans-unit>
 			<trans-unit id="header.newComment">
-				<source/>
+				<source>Add a new comment</source>
 				<target>Neuen Kommentar hinzufügen</target>
 			</trans-unit>
 			<trans-unit id="header.comments">
-				<source/>
+				<source>Comments</source>
 				<target>Kommentare</target>
 			</trans-unit>
 			<trans-unit id="header.comments.todo">
-				<source/>
+				<source>Shows the count of the pending todos within the comments</source>
 				<target>Zeigt die Anzahl der offenen ToDos aus den Kommentaren</target>
 			</trans-unit>
 
 			<!-- time ago -->
 			<trans-unit id="timeAgo.years">
-				<source/>
+				<source>%s years ago</source>
 				<target>vor %s Jahren</target>
 			</trans-unit>
 			<trans-unit id="timeAgo.year">
-				<source/>
+				<source>%s year ago</source>
 				<target>vor %s Jahr</target>
 			</trans-unit>
 			<trans-unit id="timeAgo.months">
-				<source/>
+				<source>%s months ago</source>
 				<target>vor %s Monaten</target>
 			</trans-unit>
 			<trans-unit id="timeAgo.month">
-				<source/>
+				<source>%s month ago</source>
 				<target>vor %s Monat</target>
 			</trans-unit>
 			<trans-unit id="timeAgo.days">
-				<source/>
+				<source>%s days ago</source>
 				<target>vor %s Tagen</target>
 			</trans-unit>
 			<trans-unit id="timeAgo.day">
-				<source/>
+				<source>%s day ago</source>
 				<target>vor %s Tag</target>
 			</trans-unit>
 			<trans-unit id="timeAgo.hours">
-				<source/>
+				<source>%s hours ago</source>
 				<target>vor %s Stunden</target>
 			</trans-unit>
 			<trans-unit id="timeAgo.hour">
-				<source/>
+				<source>%s hour ago</source>
 				<target>vor %s Stunde</target>
 			</trans-unit>
 			<trans-unit id="timeAgo.minutes">
-				<source/>
+				<source>%s minutes ago</source>
 				<target>vor %s Minuten</target>
 			</trans-unit>
 			<trans-unit id="timeAgo.minute">
-				<source/>
+				<source>%s minute ago</source>
 				<target>vor %s Minute</target>
 			</trans-unit>
 			<trans-unit id="timeAgo.seconds">
-				<source/>
+				<source>%s seconds ago</source>
 				<target>vor %s Sekunden</target>
 			</trans-unit>
 			<trans-unit id="timeAgo.second">
-				<source/>
+				<source>%s second ago</source>
 				<target>vor %s Sekunde</target>
 			</trans-unit>
 			<trans-unit id="timeAgo.now">
-				<source/>
+				<source>now</source>
 				<target>jetzt</target>
 			</trans-unit>
 
 			<trans-unit id="filter.reset">
-				<source/>
+				<source>Reset</source>
 				<target>Zurücksetzen</target>
 			</trans-unit>
 			<trans-unit id="filter.button">
-				<source/>
+				<source>Filter</source>
 				<target>Filter</target>
 			</trans-unit>
 			<trans-unit id="filter.modal.title">
-				<source/>
+				<source>Filter records</source>
 				<target>Datensätze filtern</target>
 			</trans-unit>
 			<trans-unit id="filter.modal.apply">
-				<source/>
+				<source>Apply</source>
 				<target>Anwenden</target>
 			</trans-unit>
 			<trans-unit id="filter.openComments">
-				<source/>
+				<source>Open comments</source>
 				<target>Offene Kommentare</target>
 			</trans-unit>
 			<trans-unit id="filter.openTodos">
-				<source/>
+				<source>Open TODOs</source>
 				<target>Offene ToDos</target>
 			</trans-unit>
 
 			<trans-unit id="comment.edited">
-				<source/>
+				<source>edited</source>
 				<target>bearbeitet</target>
 			</trans-unit>
 			<trans-unit id="comment.actions.edit">
-				<source/>
+				<source>Edit</source>
 				<target>Bearbeiten</target>
 			</trans-unit>
 			<trans-unit id="comment.actions.resolve">
-				<source/>
+				<source>Mark as resolved</source>
 				<target>Als Erledigt markieren</target>
 			</trans-unit>
 			<trans-unit id="comment.actions.resolve.title">
-				<source/>
+				<source>Resolve comment</source>
 				<target>Erledigen</target>
 			</trans-unit>
 			<trans-unit id="comment.actions.resolve.description">
-				<source/>
+				<source>Are you sure you want to mark this comment as resolved?</source>
 				<target>Sind sie sicher, dass sie den Kommentar als erledigt markieren möchten?</target>
 			</trans-unit>
 			<trans-unit id="comment.actions.resolve.button">
-				<source/>
+				<source>Resolve</source>
 				<target>Erledigen</target>
 			</trans-unit>
 			<trans-unit id="comment.actions.unresolve">
-				<source/>
+				<source>Reopen</source>
 				<target>Erneut öffnen</target>
 			</trans-unit>
 			<trans-unit id="comment.actions.unresolve.title">
-				<source/>
+				<source>Unresolve comment</source>
 				<target>Erneut öffnen</target>
 			</trans-unit>
 			<trans-unit id="comment.actions.unresolve.description">
-				<source/>
+				<source>Are you sure you want to mark this comment as unresolved?</source>
 				<target>Sind sie sicher, dass sie den Kommentar erneut öffnen möchten?</target>
 			</trans-unit>
 			<trans-unit id="comment.actions.unresolve.button">
-				<source/>
+				<source>Unresolve</source>
 				<target>Öffnen</target>
 			</trans-unit>
 			<trans-unit id="comment.actions.delete">
-				<source/>
+				<source>Delete</source>
 				<target>Löschen</target>
 			</trans-unit>
 			<trans-unit id="comment.actions.delete.title">
-				<source/>
+				<source>Delete comment</source>
 				<target>Löschen</target>
 			</trans-unit>
 			<trans-unit id="comment.actions.delete.description">
-				<source/>
+				<source>Are you sure you want to delete this comment?</source>
 				<target>Sind sie sicher, dass sie den Kommentar löschen möchten?</target>
 			</trans-unit>
 			<trans-unit id="comment.actions.delete.button">
-				<source/>
+				<source>Delete</source>
 				<target>Löschen</target>
 			</trans-unit>
 			<trans-unit id="comment.actions.share">
-				<source/>
+				<source>Share link</source>
 				<target>Link teilen</target>
 			</trans-unit>
 			<trans-unit id="comment.share.copied">
-				<source/>
+				<source>Link copied to clipboard</source>
 				<target>Link in Zwischenablage kopiert</target>
 			</trans-unit>
 			<trans-unit id="comment.share.failed">
-				<source/>
+				<source>Failed to copy link</source>
 				<target>Link konnte nicht kopiert werden</target>
 			</trans-unit>
 			<trans-unit id="comment.resolved">
-				<source/>
+				<source>Resolved by %s on %s</source>
 				<target>Erledigt von %s am %s</target>
 			</trans-unit>
 			<trans-unit id="comment.empty">
-				<source/>
+				<source><![CDATA[Currently there are no comments available yet. You may want to create a <a data-new-comment-uri="%s" data-table="%s" data-id="%s">new comment</a>?]]></source>
 				<target><![CDATA[Aktuell gibt es keine Kommentare. Du möchtest vielleicht ein <a data-new-comment-uri="%s" data-table="%s" data-id="%s">neuen Kommentar</a> erstellen?]]></target>
 			</trans-unit>
 
 			<trans-unit id="assignee.selection.label">
-				<source/>
+				<source>Select an assignee</source>
 				<target>Zuständigen auswählen</target>
 			</trans-unit>
 			<trans-unit id="assignee.info">
-				<source/>
+				<source>For every content planner record, a dedicated assignee can be set. The assignee is the backend user responsible for the current record.</source>
 				<target>Für jeden Content Planner-Datensatz kann ein eigener zuständige Nutzer festgelegt werden. Der Zuständige ist der Backend-Benutzer, der für den aktuellen Datensatz verantwortlich ist.</target>
 			</trans-unit>
 			<trans-unit id="assignee.further">
-				<source/>
+				<source>Further information</source>
 				<target>Weitere Informationen</target>
 			</trans-unit>
 			<trans-unit id="assignee.shortcut">
-				<source/>
+				<source>Use the shortcut buttons to easily assign the record to yourself (%s) or unassign it (%s).</source>
 				<target>Nutze die Shortcut Buttons, um den Datensatz einfach dir selbst (%s) zuzuweisen oder die Zuweisung aufzuheben (%s).</target>
 			</trans-unit>
 			<trans-unit id="assignee.permission">
-				<source/>
+				<source>Only admins and backend users with the necessary permission are shown in the assignee selection.</source>
 				<target>Nur Admins und Backend-Benutzer mit entsprechender Berechtigung werden in der Zuständigen-Auswahl angezeigt.</target>
 			</trans-unit>
 			<trans-unit id="assignee.documentation">
-				<source/>
+				<source><![CDATA[You can find more information about the assignee feature in the <a href="https://docs.typo3.org/p/xima/xima-typo3-content-planner/main/en-us/Usage/Assignee.html" target="_blank">official documentation</a> of the extension.]]></source>
 				<target><![CDATA[Weitere Informationen zur Zuständigen-Funktion findest du in der <a href="https://docs.typo3.org/p/xima/xima-typo3-content-planner/main/de-de/Usage/Assignee.html" target="_blank">offiziellen Dokumentation</a> der Extension.]]></target>
 			</trans-unit>
 		</body>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -208,7 +208,7 @@
 			</trans-unit>
 			<trans-unit id="button.modal.footer.edit">
 				<source>Edit</source>
-				<target>Edit</target>
+				<target>Bearbeiten</target>
 			</trans-unit>
 			<trans-unit id="button.modal.footer.save">
 				<source>Save</source>

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -56,11 +56,11 @@
 				<target><![CDATA[Der <em>Status</em> wurde auf <strong>%s</strong> gesetzt]]></target>
 			</trans-unit>
 			<trans-unit id="history.record.2.unset.tx_ximatypo3contentplanner_status">
-				<source><![CDATA[The <em>status</em>  was unset from <strong>%s</strong>]]></source>
+				<source><![CDATA[The <em>status</em> was unset from <strong>%s</strong>]]></source>
 				<target><![CDATA[Der <em>Status</em> wurde von <strong>%s</strong> entfernt]]></target>
 			</trans-unit>
 			<trans-unit id="history.record.2.change.tx_ximatypo3contentplanner_status">
-				<source><![CDATA[The <em>status</em>  was changed from <strong>%s</strong> to <strong>%s</strong>]]></source>
+				<source><![CDATA[The <em>status</em> was changed from <strong>%s</strong> to <strong>%s</strong>]]></source>
 				<target><![CDATA[Der <em>Status</em> wurde von <strong>%s</strong> zu <strong>%s</strong> geändert]]></target>
 			</trans-unit>
 			<trans-unit id="history.record.2.set.tx_ximatypo3contentplanner_assignee">
@@ -92,7 +92,7 @@
 				<target><![CDATA[Ein <em>Kommentar</em> wurde wieder geöffnet]]></target>
 			</trans-unit>
 			<trans-unit id="history.comment.4">
-				<source><![CDATA[A <em>comment</em> was been removed]]></source>
+				<source><![CDATA[A <em>comment</em> has been removed]]></source>
 				<target><![CDATA[Ein <em>Kommentar</em> wurde entfernt]]></target>
 			</trans-unit>
 

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -4,221 +4,225 @@
 		<header/>
 		<body>
 			<trans-unit id="status">
-				<source/>
+				<source>Content Status</source>
 				<target>Inhaltsstatus</target>
 			</trans-unit>
 			<trans-unit id="status.danger">
-				<source/>
+				<source>Pending</source>
 				<target>Ausstehend</target>
 			</trans-unit>
 			<trans-unit id="status.info">
-				<source/>
+				<source>In progress</source>
 				<target>In Bearbeitung</target>
 			</trans-unit>
 			<trans-unit id="status.warning">
-				<source/>
+				<source>Needs review</source>
 				<target>Benötigt Überprüfung</target>
 			</trans-unit>
 			<trans-unit id="status.success">
-				<source/>
+				<source>Completed</source>
 				<target>Abgeschlossen</target>
 			</trans-unit>
 			<trans-unit id="reset">
-				<source/>
+				<source>Reset Status</source>
 				<target>Status zurücksetzen</target>
 			</trans-unit>
 			<trans-unit id="comment">
-				<source/>
+				<source>Content Planner Comment</source>
 				<target>Content Planner Kommentar</target>
 			</trans-unit>
 			<trans-unit id="comments">
-				<source/>
+				<source>Comment(s)</source>
 				<target>Kommentar(e)</target>
 			</trans-unit>
 			<trans-unit id="comments.todo">
 				<source>ToDo(s)</source>
 			</trans-unit>
 			<trans-unit id="currentAssignee">
-				<source/>
+				<source>Current Assignee</source>
 				<target>Aktueller Zuständiger</target>
 			</trans-unit>
+			<trans-unit id="header.unassigned">
+				<source>-- Not assigned --</source>
+				<target>-- Nicht zugewiesen --</target>
+			</trans-unit>
 			<trans-unit id="save_and_close">
-				<source/>
+				<source>Save and Close</source>
 				<target>Speichern und Schließen</target>
 			</trans-unit>
 			<!-- history -->
 			<trans-unit id="history.record.2.set.tx_ximatypo3contentplanner_status">
-				<source/>
+				<source><![CDATA[The <em>status</em> was set to <strong>%s</strong>]]></source>
 				<target><![CDATA[Der <em>Status</em> wurde auf <strong>%s</strong> gesetzt]]></target>
 			</trans-unit>
 			<trans-unit id="history.record.2.unset.tx_ximatypo3contentplanner_status">
-				<source/>
+				<source><![CDATA[The <em>status</em>  was unset from <strong>%s</strong>]]></source>
 				<target><![CDATA[Der <em>Status</em> wurde von <strong>%s</strong> entfernt]]></target>
 			</trans-unit>
 			<trans-unit id="history.record.2.change.tx_ximatypo3contentplanner_status">
-				<source/>
+				<source><![CDATA[The <em>status</em>  was changed from <strong>%s</strong> to <strong>%s</strong>]]></source>
 				<target><![CDATA[Der <em>Status</em> wurde von <strong>%s</strong> zu <strong>%s</strong> geändert]]></target>
 			</trans-unit>
 			<trans-unit id="history.record.2.set.tx_ximatypo3contentplanner_assignee">
-				<source/>
+				<source><![CDATA[The <em>assignee</em> was set to <strong>%s</strong>]]></source>
 				<target><![CDATA[Die <em>Zuständigkeit</em> wurde auf <strong>%s</strong> gesetzt]]></target>
 			</trans-unit>
 			<trans-unit id="history.record.2.unset.tx_ximatypo3contentplanner_assignee">
-				<source/>
+				<source><![CDATA[The <em>assignee</em> was unset from <strong>%s</strong>]]></source>
 				<target><![CDATA[Die <em>Zuständigkeit</em> wurde von <strong>%s</strong> entfernt]]></target>
 			</trans-unit>
 			<trans-unit id="history.record.2.change.tx_ximatypo3contentplanner_assignee">
-				<source/>
+				<source><![CDATA[The <em>assignee</em> was changed from <strong>%s</strong> to <strong>%s</strong>]]></source>
 				<target><![CDATA[Die <em>Zuständigkeit</em> wurde von <strong>%s</strong> zu <strong>%s</strong> geändert]]></target>
 			</trans-unit>
 			<trans-unit id="history.comment.1">
-				<source/>
+				<source><![CDATA[A new <em>comment</em> has been added]]></source>
 				<target><![CDATA[Ein neuer <em>Kommentar</em> wurde hinzugefügt]]></target>
 			</trans-unit>
 			<trans-unit id="history.comment.2">
-				<source/>
+				<source><![CDATA[A <em>comment</em> was updated]]></source>
 				<target><![CDATA[Ein <em>Kommentar</em> wurde aktualisiert]]></target>
 			</trans-unit>
 			<trans-unit id="history.comment.2.resolved">
-				<source/>
+				<source><![CDATA[A <em>comment</em> was marked as resolved]]></source>
 				<target><![CDATA[Ein <em>Kommentar</em> wurde als erledigt markiert]]></target>
 			</trans-unit>
 			<trans-unit id="history.comment.2.unresolved">
-				<source/>
+				<source><![CDATA[A <em>comment</em> was reopened]]></source>
 				<target><![CDATA[Ein <em>Kommentar</em> wurde wieder geöffnet]]></target>
 			</trans-unit>
 			<trans-unit id="history.comment.4">
-				<source/>
+				<source><![CDATA[A <em>comment</em> was been removed]]></source>
 				<target><![CDATA[Ein <em>Kommentar</em> wurde entfernt]]></target>
 			</trans-unit>
 
 			<trans-unit id="message.status.changed.success.title">
-				<source/>
+				<source>Status changed</source>
 				<target>Status geändert</target>
 			</trans-unit>
 			<trans-unit id="message.status.changed.success.message">
-				<source/>
+				<source>The status of the record has been changed successfully.</source>
 				<target>Der Status des Eintrags wurde erfolgreich geändert.</target>
 			</trans-unit>
 			<trans-unit id="message.status.changed.failure.title">
-				<source/>
+				<source>Status change failed</source>
 				<target>Status konnte nicht geändert werden</target>
 			</trans-unit>
 			<trans-unit id="message.status.changed.failure.message">
-				<source/>
+				<source>The status of the record could not be changed.</source>
 				<target>Der Status des Eintrags konnte nicht geändert werden.</target>
 			</trans-unit>
 			<trans-unit id="message.status.reset.success.title">
-				<source/>
+				<source>Status reset</source>
 				<target>Status entfernt</target>
 			</trans-unit>
 			<trans-unit id="message.status.reset.success.message">
-				<source/>
+				<source>The status of the record has been unset successfully.</source>
 				<target>Der Status des Eintrags wurde erfolgreich entfernt.</target>
 			</trans-unit>
 			<trans-unit id="message.status.reset.failure.title">
-				<source/>
+				<source>Status reset failed</source>
 				<target>Status konnte nicht entfernt werden</target>
 			</trans-unit>
 			<trans-unit id="message.status.reset.failure.message">
-				<source/>
+				<source>The status of the record could not be unset.</source>
 				<target>Der Status des Eintrags konnte nicht entfernt werden.</target>
 			</trans-unit>
 			<trans-unit id="message.assignee.changed.success.title">
-				<source/>
+				<source>Assignee changed</source>
 				<target>Zuständigkeit geändert</target>
 			</trans-unit>
 			<trans-unit id="message.assignee.changed.success.message">
-				<source/>
+				<source>The assignee of the record has been changed successfully.</source>
 				<target>Die Zuständigkeit des Eintrags wurde erfolgreich geändert.</target>
 			</trans-unit>
 			<trans-unit id="message.assignee.changed.failure.title">
-				<source/>
+				<source>Assignee change failed</source>
 				<target>Zuständigkeit konnte nicht geändert werden</target>
 			</trans-unit>
 			<trans-unit id="message.assignee.changed.failure.message">
-				<source/>
+				<source>The assignee of the record could not be changed.</source>
 				<target>Die Zuständigkeit des Eintrags konnte nicht geändert werden.</target>
 			</trans-unit>
 			<trans-unit id="message.assignee.reset.success.title">
-				<source/>
+				<source>Assignee reset</source>
 				<target>Zuständigkeit entfernt</target>
 			</trans-unit>
 			<trans-unit id="message.assignee.reset.success.message">
-				<source/>
+				<source>The assignee of the record has been unset successfully.</source>
 				<target>Die Zuständigkeit des Eintrags wurde erfolgreich entfernt.</target>
 			</trans-unit>
 			<trans-unit id="message.assignee.reset.failure.title">
-				<source/>
+				<source>Assignee reset failed</source>
 				<target>Zuständigkeit konnte nicht entfernt werden</target>
 			</trans-unit>
 			<trans-unit id="message.assignee.reset.failure.message">
-				<source/>
+				<source>The assignee of the record could not be unset.</source>
 				<target>Die Zuständigkeit des Eintrags konnte nicht entfernt werden.</target>
 			</trans-unit>
 			<trans-unit id="message.comment.create.success.title">
-				  <source/>
-				  <target>Kommentar erstellt</target>
+				<source>Comment created</source>
+				<target>Kommentar erstellt</target>
 			</trans-unit>
 			<trans-unit id="message.comment.create.success.message">
-				  <source/>
-				  <target>Der Kommentar wurde erfolgreich erstellt.</target>
+				<source>The comment has been created successfully.</source>
+				<target>Der Kommentar wurde erfolgreich erstellt.</target>
 			</trans-unit>
 			<trans-unit id="message.comment.create.failure.title">
-				  <source/>
-				  <target>Kommentar konnte nicht erstellt werden</target>
+				<source>Comment create failed</source>
+				<target>Kommentar konnte nicht erstellt werden</target>
 			</trans-unit>
 			<trans-unit id="message.comment.create.failure.message">
-				  <source/>
-				  <target>Der Kommentar konnte nicht erstellt werden.</target>
+				<source>The comment could not be created.</source>
+				<target>Der Kommentar konnte nicht erstellt werden.</target>
 			</trans-unit>
 			<trans-unit id="message.comment.edit.success.title">
-				 <source/>
-				 <target>Kommentar bearbeitet</target>
+				<source>Comment edited</source>
+				<target>Kommentar bearbeitet</target>
 			</trans-unit>
 			<trans-unit id="message.comment.edit.success.message">
-				 <source/>
-				 <target>Der Kommentar wurde erfolgreich bearbeitet.</target>
+				<source>The comment has been edited successfully.</source>
+				<target>Der Kommentar wurde erfolgreich bearbeitet.</target>
 			</trans-unit>
 			<trans-unit id="message.comment.edit.failure.title">
-				 <source/>
-				 <target>Kommentar konnte nicht bearbeitet werden</target>
+				<source>Comment edit failed</source>
+				<target>Kommentar konnte nicht bearbeitet werden</target>
 			</trans-unit>
 			<trans-unit id="message.comment.edit.failure.message">
-				 <source/>
-				 <target>Der Kommentar konnte nicht bearbeitet werden.</target>
+				<source>The comment could not be edited.</source>
+				<target>Der Kommentar konnte nicht bearbeitet werden.</target>
 			</trans-unit>
 			<trans-unit id="message.comment.resolve.success.title">
-				 <source/>
-				 <target>Kommentar erledigt</target>
+				<source>Comment resolved</source>
+				<target>Kommentar erledigt</target>
 			</trans-unit>
 			<trans-unit id="message.comment.resolve.success.message">
-				 <source/>
-				 <target>Der Kommentar wurde als erledigt markiert.</target>
+				<source>The comment has been marked as resolved.</source>
+				<target>Der Kommentar wurde als erledigt markiert.</target>
 			</trans-unit>
 			<trans-unit id="message.comment.resolve.failure.title">
-				 <source/>
-				 <target>Kommentar konnte nicht erledigt werden</target>
+				<source>Comment resolve failed</source>
+				<target>Kommentar konnte nicht erledigt werden</target>
 			</trans-unit>
 			<trans-unit id="message.comment.resolve.failure.message">
-				 <source/>
-				 <target>Der Kommentar konnte nicht als erledigt markiert werden.</target>
+				<source>The comment could not be marked as resolved.</source>
+				<target>Der Kommentar konnte nicht als erledigt markiert werden.</target>
 			</trans-unit>
 			<trans-unit id="message.comment.delete.success.title">
-				 <source/>
-				 <target>Kommentar gelöscht</target>
+				<source>Comment deleted</source>
+				<target>Kommentar gelöscht</target>
 			</trans-unit>
 			<trans-unit id="message.comment.delete.success.message">
-				 <source/>
-				 <target>Der Kommentar wurde erfolgreich gelöscht.</target>
+				<source>The comment has been deleted successfully.</source>
+				<target>Der Kommentar wurde erfolgreich gelöscht.</target>
 			</trans-unit>
 			<trans-unit id="message.comment.delete.failure.title">
-				 <source/>
-				 <target>Kommentar konnte nicht gelöscht werden</target>
+				<source>Comment delete failed</source>
+				<target>Kommentar konnte nicht gelöscht werden</target>
 			</trans-unit>
 			<trans-unit id="message.comment.delete.failure.message">
-				 <source/>
-				 <target>Der Kommentar konnte nicht gelöscht werden.</target>
+				<source>The comment could not be deleted.</source>
+				<target>Der Kommentar konnte nicht gelöscht werden.</target>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -4,183 +4,183 @@
 		<header/>
 		<body>
 			<trans-unit id="pages.tx_ximatypo3contentplanner_status">
-				<source/>
+				<source>Status</source>
 				<target>Status</target>
 			</trans-unit>
 			<trans-unit id="pages.tx_ximatypo3contentplanner_comments">
-				<source/>
+				<source>Comments</source>
 				<target>Kommentare</target>
 			</trans-unit>
 			<trans-unit id="pages.tx_ximatypo3contentplanner_assignee">
-				<source/>
+				<source>Assignee</source>
 				<target>Zuständigkeit</target>
 			</trans-unit>
 			<trans-unit id="pages.tx_ximatypo3contentplanner_assignee.empty">
-				<source/>
+				<source>-- Not assigned --</source>
 				<target>-- Nicht zugewiesen --</target>
 			</trans-unit>
 			<trans-unit id="tx_ximatypo3contentplanner_comment.content">
-				<source/>
+				<source>Content</source>
 				<target>Inhalt</target>
 			</trans-unit>
 			<trans-unit id="tx_ximatypo3contentplanner_comment.resolved">
-				<source/>
+				<source>Resolved</source>
 				<target>Erledigt</target>
 			</trans-unit>
 			<trans-unit id="tx_ximatypo3contentplanner_comment.author">
-				<source/>
+				<source>Author</source>
 				<target>Autor</target>
 			</trans-unit>
 			<trans-unit id="be_users.tx_ximatypo3contentplanner_hide">
-				<source/>
+				<source>Hide content planner</source>
 				<target>Content Planner ausblenden</target>
 			</trans-unit>
 			<trans-unit id="be_users.tx_ximatypo3contentplanner_hide.description">
-				<source/>
+				<source>Disable the display of content planner status information and color within the TYPO3 backend</source>
 				<target>Deaktivieren Sie die Anzeige von Content Planner Statusinformationen und Farben im TYPO3-Backend</target>
 			</trans-unit>
 			<trans-unit id="tx_ximatypo3contentplanner_status.title">
-				<source/>
+				<source>Title</source>
 				<target>Titel</target>
 			</trans-unit>
 			<trans-unit id="tx_ximatypo3contentplanner_status.icon">
-				<source/>
+				<source>Icon</source>
 				<target>Symbol</target>
 			</trans-unit>
 			<trans-unit id="tx_ximatypo3contentplanner_status.color">
-				<source/>
+				<source>Color</source>
 				<target>Farbe</target>
 			</trans-unit>
 			<trans-unit id="permission.group">
-				<source/>
+				<source>Content Planner</source>
 				<target>Content Planner</target>
 			</trans-unit>
 			<trans-unit id="permission.view_only">
-				<source/>
+				<source>View Only</source>
 				<target>Nur Ansicht</target>
 			</trans-unit>
 			<trans-unit id="permission.view_only.description">
-				<source/>
+				<source>Allow viewing Content Planner status information (read-only, no actions)</source>
 				<target>Erlaubt das Anzeigen von Content Planner Statusinformationen (nur lesen, keine Aktionen)</target>
 			</trans-unit>
 			<trans-unit id="permission.content_status">
-				<source/>
+				<source>Full Access</source>
 				<target>Vollzugriff</target>
 			</trans-unit>
 			<trans-unit id="permission.content_status.description">
-				<source/>
+				<source>Grants full access to all Content Planner features</source>
 				<target>Gewährt vollen Zugriff auf alle Content Planner Funktionen</target>
 			</trans-unit>
 			<trans-unit id="permission.status_change">
-				<source/>
+				<source>Change Status</source>
 				<target>Status ändern</target>
 			</trans-unit>
 			<trans-unit id="permission.status_change.description">
-				<source/>
+				<source>Allow changing the status of records</source>
 				<target>Erlaubt das Ändern des Status von Datensätzen</target>
 			</trans-unit>
 			<trans-unit id="permission.status_unset">
-				<source/>
+				<source>Unset Status</source>
 				<target>Status entfernen</target>
 			</trans-unit>
 			<trans-unit id="permission.status_unset.description">
-				<source/>
+				<source>Allow removing the status from records</source>
 				<target>Erlaubt das Entfernen des Status von Datensätzen</target>
 			</trans-unit>
 			<trans-unit id="permission.comment_create">
-				<source/>
+				<source>Create Comments</source>
 				<target>Kommentare erstellen</target>
 			</trans-unit>
 			<trans-unit id="permission.comment_create.description">
-				<source/>
+				<source>Allow creating new comments on records</source>
 				<target>Erlaubt das Erstellen neuer Kommentare an Datensätzen</target>
 			</trans-unit>
 			<trans-unit id="permission.comment_edit_own">
-				<source/>
+				<source>Edit Own Comments</source>
 				<target>Eigene Kommentare bearbeiten</target>
 			</trans-unit>
 			<trans-unit id="permission.comment_edit_own.description">
-				<source/>
+				<source>Allow editing of own comments</source>
 				<target>Erlaubt das Bearbeiten eigener Kommentare</target>
 			</trans-unit>
 			<trans-unit id="permission.comment_edit_foreign">
-				<source/>
+				<source>Edit Foreign Comments</source>
 				<target>Fremde Kommentare bearbeiten</target>
 			</trans-unit>
 			<trans-unit id="permission.comment_edit_foreign.description">
-				<source/>
+				<source>Allow editing of comments from other users</source>
 				<target>Erlaubt das Bearbeiten von Kommentaren anderer Benutzer</target>
 			</trans-unit>
 			<trans-unit id="permission.comment_resolve">
-				<source/>
+				<source>Resolve Comments</source>
 				<target>Kommentare auflösen</target>
 			</trans-unit>
 			<trans-unit id="permission.comment_resolve.description">
-				<source/>
+				<source>Allow marking comments as resolved</source>
 				<target>Erlaubt das Markieren von Kommentaren als erledigt</target>
 			</trans-unit>
 			<trans-unit id="permission.comment_delete_own">
-				<source/>
+				<source>Delete Own Comments</source>
 				<target>Eigene Kommentare löschen</target>
 			</trans-unit>
 			<trans-unit id="permission.comment_delete_own.description">
-				<source/>
+				<source>Allow deletion of own comments</source>
 				<target>Erlaubt das Löschen eigener Kommentare</target>
 			</trans-unit>
 			<trans-unit id="permission.comment_delete_foreign">
-				<source/>
+				<source>Delete Foreign Comments</source>
 				<target>Fremde Kommentare löschen</target>
 			</trans-unit>
 			<trans-unit id="permission.comment_delete_foreign.description">
-				<source/>
+				<source>Allow deletion of comments from other users</source>
 				<target>Erlaubt das Löschen von Kommentaren anderer Benutzer</target>
 			</trans-unit>
 			<trans-unit id="permission.assign_self">
-				<source/>
+				<source>Assign Self</source>
 				<target>Sich selbst zuweisen</target>
 			</trans-unit>
 			<trans-unit id="permission.assign_self.description">
-				<source/>
+				<source>Allow assigning and unassigning yourself</source>
 				<target>Erlaubt das Zuweisen und Entfernen der eigenen Zuständigkeit</target>
 			</trans-unit>
 			<trans-unit id="permission.assign_others">
-				<source/>
+				<source>Assign Others</source>
 				<target>Andere zuweisen</target>
 			</trans-unit>
 			<trans-unit id="permission.assign_others.description">
-				<source/>
+				<source>Allow assigning, reassigning and unassigning any user</source>
 				<target>Erlaubt das Zuweisen, Umhängen und Entfernen beliebiger Zuständigkeiten</target>
 			</trans-unit>
 			<trans-unit id="be_groups.tx_ximatypo3contentplanner_allowed_statuses">
-				<source/>
+				<source>Allowed Statuses</source>
 				<target>Erlaubte Status</target>
 			</trans-unit>
 			<trans-unit id="be_groups.tx_ximatypo3contentplanner_allowed_statuses.description">
-				<source/>
+				<source>Restrict which statuses this group can use. Leave empty to allow all statuses.</source>
 				<target>Beschränkt, welche Status diese Gruppe verwenden kann. Leer lassen für alle Status.</target>
 			</trans-unit>
 			<trans-unit id="be_groups.tx_ximatypo3contentplanner_allowed_tables">
-				<source/>
+				<source>Allowed Tables</source>
 				<target>Erlaubte Tabellen</target>
 			</trans-unit>
 			<trans-unit id="be_groups.tx_ximatypo3contentplanner_allowed_tables.description">
-				<source/>
+				<source>Restrict which record tables this group can manage. Leave empty to allow all tables.</source>
 				<target>Beschränkt, welche Tabellen diese Gruppe verwalten kann. Leer lassen für alle Tabellen.</target>
 			</trans-unit>
 			<trans-unit id="content_planner">
-				<source/>
+				<source>Content Planner</source>
 				<target>Content Planner</target>
 			</trans-unit>
 			<trans-unit id="tx_ximatypo3contentplanner_folder">
-				<source/>
+				<source>Folder Status</source>
 				<target>Ordner-Status</target>
 			</trans-unit>
 			<trans-unit id="tx_ximatypo3contentplanner_folder.folder_identifier">
-				<source/>
+				<source>Folder Path</source>
 				<target>Ordner-Pfad</target>
 			</trans-unit>
 			<trans-unit id="tx_ximatypo3contentplanner_folder.storage_uid">
-				<source/>
+				<source>Storage</source>
 				<target>Speicher</target>
 			</trans-unit>
 		</body>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -44,10 +44,10 @@
 				<source><![CDATA[The <em>status</em> was set to <strong>%s</strong>]]></source>
 			</trans-unit>
 			<trans-unit id="history.record.2.unset.tx_ximatypo3contentplanner_status">
-				<source><![CDATA[The <em>status</em>  was unset from <strong>%s</strong>]]></source>
+				<source><![CDATA[The <em>status</em> was unset from <strong>%s</strong>]]></source>
 			</trans-unit>
 			<trans-unit id="history.record.2.change.tx_ximatypo3contentplanner_status">
-				<source><![CDATA[The <em>status</em>  was changed from <strong>%s</strong> to <strong>%s</strong>]]></source>
+				<source><![CDATA[The <em>status</em> was changed from <strong>%s</strong> to <strong>%s</strong>]]></source>
 			</trans-unit>
 			<trans-unit id="history.record.2.set.tx_ximatypo3contentplanner_assignee">
 				<source><![CDATA[The <em>assignee</em> was set to <strong>%s</strong>]]></source>
@@ -71,7 +71,7 @@
 				<source><![CDATA[A <em>comment</em> was reopened]]></source>
 			</trans-unit>
 			<trans-unit id="history.comment.4">
-				<source><![CDATA[A <em>comment</em> was been removed]]></source>
+				<source><![CDATA[A <em>comment</em> has been removed]]></source>
 			</trans-unit>
 
 			<trans-unit id="message.status.changed.success.title">


### PR DESCRIPTION
## Summary

- Add missing `<source>` values to all German translation files (`de.locallang*.xlf`)
- Add defensive `isValid()` check before adding items to DropDownButton

## Problem

German backend users on TYPO3 v14 encountered a crash:
```
Only valid items may be assigned to a DropdownButton. "DropDownHeader" did not pass validation
```

All `<source>` tags in the German XLIFF files were empty (`<source/>`), causing `LanguageService::sL()` to return empty strings in TYPO3 v14. This made `DropDownHeader::isValid()` fail since it requires a non-empty label.

English backend users were unaffected because the primary `locallang_be.xlf` had correct source values.

## Changes

- `Resources/Private/Language/de.locallang.xlf` - Add English source values to all trans-units
- `Resources/Private/Language/de.locallang_be.xlf` - Add English source values, add missing `header.unassigned` key
- `Resources/Private/Language/de.locallang_db.xlf` - Add English source values to all trans-units
- `Classes/EventListener/ModifyButtonBarEventListener.php` - Skip invalid items instead of crashing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid dropdown items no longer appear in the button bar.

* **Localization**
  * Expanded German translations across dashboard widgets, content status labels, comment management, assignee handling, backend UI actions, notifications, and permission descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->