### PR TITLE
chore: downgrade DDEV PHP version to 8.2

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,7 +1,7 @@
 name: xima-typo3-content-planner
 type: php
 docroot: .Build
-php_version: "8.3"
+php_version: "8.2"
 webserver_type: apache-fpm
 xdebug_enabled: false
 additional_hostnames:


### PR DESCRIPTION
## Summary

- Downgrade DDEV PHP version from 8.3 to 8.2 to match the extension's minimum requirement

## Changes

- `.ddev/config.yaml` - Set `php_version` from `8.3` to `8.2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment PHP runtime configuration to version 8.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->