### PR TITLE
feat: cascade-delete comments when tracked record is deleted

### DIFF
--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -102,7 +102,10 @@ final readonly class DataHandlerHook // @phpstan-ignore-line complexity.classLik
 
         // Check comment delete permission
         if (Configuration::TABLE_COMMENT === $table) {
-            $this->guardCommentDeletePermission((int) $id, $table, $parentObject);
+            $comment = $this->commentRepository->findByUid((int) $id);
+            if ($comment && !PermissionUtility::canDeleteComment($comment)) {
+                unset($parentObject->cmdmap[$table][$id]);
+            }
         }
     }
 
@@ -163,14 +166,6 @@ final readonly class DataHandlerHook // @phpstan-ignore-line complexity.classLik
             $tags[] = $params['table'].'__pageId__'.$params['uid_page'];
         }
         $this->cache->flushByTags($tags);
-    }
-
-    private function guardCommentDeletePermission(int $id, string $table, DataHandler $parentObject): void
-    {
-        $comment = $this->commentRepository->findByUid($id);
-        if ($comment && !PermissionUtility::canDeleteComment($comment)) {
-            unset($parentObject->cmdmap[$table][$id]);
-        }
     }
 
     private function fixNewCommentEntry(DataHandler &$dataHandler): void

--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -84,10 +84,16 @@ final readonly class DataHandlerHook // @phpstan-ignore-line complexity.classLik
      */
     public function processCmdmap_preProcess($command, $table, $id, &$value, DataHandler $parentObject, $pasteUpdate): void
     {
-        if (!MathUtility::canBeInterpretedAsInteger($id)) {
+        if (!MathUtility::canBeInterpretedAsInteger($id) || 'delete' !== $command) {
             return;
         }
-        if ('delete' === $command && Configuration::TABLE_STATUS === $table) {
+
+        // Cascade-delete comments when a tracked record is deleted
+        if (ExtensionUtility::isRegisteredRecordTable($table)) {
+            $this->commentRepository->deleteAllCommentsByRecord((int) $id, $table);
+        }
+
+        if (Configuration::TABLE_STATUS === $table) {
             // Clear all status of records that are assigned to the deleted status
             foreach (ExtensionUtility::getRecordTables() as $recordTable) {
                 $this->statusChangeManager->clearStatusOfExtensionRecords($recordTable, (int) $id);
@@ -95,12 +101,8 @@ final readonly class DataHandlerHook // @phpstan-ignore-line complexity.classLik
         }
 
         // Check comment delete permission
-        if ('delete' === $command && Configuration::TABLE_COMMENT === $table) {
-            $comment = $this->commentRepository->findByUid((int) $id);
-            if ($comment && !PermissionUtility::canDeleteComment($comment)) {
-                // Prevent deletion by removing the command from the command map
-                unset($parentObject->cmdmap[$table][$id]);
-            }
+        if (Configuration::TABLE_COMMENT === $table) {
+            $this->guardCommentDeletePermission((int) $id, $table, $parentObject);
         }
     }
 
@@ -161,6 +163,14 @@ final readonly class DataHandlerHook // @phpstan-ignore-line complexity.classLik
             $tags[] = $params['table'].'__pageId__'.$params['uid_page'];
         }
         $this->cache->flushByTags($tags);
+    }
+
+    private function guardCommentDeletePermission(int $id, string $table, DataHandler $parentObject): void
+    {
+        $comment = $this->commentRepository->findByUid($id);
+        if ($comment && !PermissionUtility::canDeleteComment($comment)) {
+            unset($parentObject->cmdmap[$table][$id]);
+        }
     }
 
     private function fixNewCommentEntry(DataHandler &$dataHandler): void


### PR DESCRIPTION
## Summary

- Soft-delete associated comments when a tracked record (page, tt_content, etc.) is deleted via DataHandler
- Reuses existing `deleteAllCommentsByRecord()` which sets `deleted=1` and resets the parent comment counter

## Changes

- `DataHandlerHook.php` — add cascade-delete block in `processCmdmap_preProcess` for registered record tables