### PR TITLE
feat: add PSR-14 events for comment creation and resolution

### DIFF
--- a/Classes/Event/CommentCreatedEvent.php
+++ b/Classes/Event/CommentCreatedEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Event;
+
+/**
+ * CommentCreatedEvent.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class CommentCreatedEvent
+{
+    public function __construct(
+        private readonly string $table,
+        private readonly int $recordUid,
+        private readonly int $commentUid,
+        private readonly int $authorUid,
+    ) {}
+
+    public function getTable(): string
+    {
+        return $this->table;
+    }
+
+    public function getRecordUid(): int
+    {
+        return $this->recordUid;
+    }
+
+    public function getCommentUid(): int
+    {
+        return $this->commentUid;
+    }
+
+    public function getAuthorUid(): int
+    {
+        return $this->authorUid;
+    }
+}

--- a/Classes/Event/CommentCreatedEvent.php
+++ b/Classes/Event/CommentCreatedEvent.php
@@ -19,13 +19,13 @@ namespace Xima\XimaTypo3ContentPlanner\Event;
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */
-final class CommentCreatedEvent
+final readonly class CommentCreatedEvent
 {
     public function __construct(
-        private readonly string $table,
-        private readonly int $recordUid,
-        private readonly int $commentUid,
-        private readonly int $authorUid,
+        private string $table,
+        private int $recordUid,
+        private int $commentUid,
+        private int $authorUid,
     ) {}
 
     public function getTable(): string

--- a/Classes/Event/CommentResolvedEvent.php
+++ b/Classes/Event/CommentResolvedEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Event;
+
+/**
+ * CommentResolvedEvent.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class CommentResolvedEvent
+{
+    public function __construct(
+        private readonly string $table,
+        private readonly int $recordUid,
+        private readonly int $commentUid,
+        private readonly int $resolvedByUid,
+    ) {}
+
+    public function getTable(): string
+    {
+        return $this->table;
+    }
+
+    public function getRecordUid(): int
+    {
+        return $this->recordUid;
+    }
+
+    public function getCommentUid(): int
+    {
+        return $this->commentUid;
+    }
+
+    public function getResolvedByUid(): int
+    {
+        return $this->resolvedByUid;
+    }
+}

--- a/Classes/Event/CommentResolvedEvent.php
+++ b/Classes/Event/CommentResolvedEvent.php
@@ -19,13 +19,13 @@ namespace Xima\XimaTypo3ContentPlanner\Event;
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */
-final class CommentResolvedEvent
+final readonly class CommentResolvedEvent
 {
     public function __construct(
-        private readonly string $table,
-        private readonly int $recordUid,
-        private readonly int $commentUid,
-        private readonly int $resolvedByUid,
+        private string $table,
+        private int $recordUid,
+        private int $commentUid,
+        private int $resolvedByUid,
     ) {}
 
     public function getTable(): string

--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -15,12 +15,14 @@ namespace Xima\XimaTypo3ContentPlanner\Hooks;
 
 use Doctrine\DBAL\Exception;
 use DOMDocument;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use Xima\XimaTypo3ContentPlanner\Configuration;
 use Xima\XimaTypo3ContentPlanner\Domain\Repository\{CommentRepository, RecordRepository};
+use Xima\XimaTypo3ContentPlanner\Event\{CommentCreatedEvent, CommentResolvedEvent};
 use Xima\XimaTypo3ContentPlanner\Manager\StatusChangeManager;
 use Xima\XimaTypo3ContentPlanner\Utility\ExtensionUtility;
 use Xima\XimaTypo3ContentPlanner\Utility\Security\PermissionUtility;
@@ -41,6 +43,7 @@ final readonly class DataHandlerHook // @phpstan-ignore-line complexity.classLik
         private StatusChangeManager $statusChangeManager,
         private RecordRepository $recordRepository,
         private CommentRepository $commentRepository,
+        private EventDispatcherInterface $eventDispatcher,
     ) {}
 
     /**
@@ -129,9 +132,39 @@ final readonly class DataHandlerHook // @phpstan-ignore-line complexity.classLik
      *
      * @throws Exception
      */
-    public function processDatamap_afterDatabaseOperations($status, $table, $id, $fieldArray, DataHandler $dataHandler): void
+    public function processDatamap_afterDatabaseOperations($status, $table, $id, $fieldArray, DataHandler $dataHandler): void // @phpstan-ignore-line complexity.functionLike
     {
         if (Configuration::TABLE_COMMENT === $table) {
+            // Dispatch CommentCreatedEvent for new comments
+            if ('new' === $status) {
+                $resolvedId = $dataHandler->substNEWwithIDs[$id] ?? null;
+                if (null !== $resolvedId && isset($fieldArray['foreign_table'], $fieldArray['foreign_uid'])) {
+                    /** @var BackendUserAuthentication $backendUser */
+                    $backendUser = $GLOBALS['BE_USER'];
+                    $this->eventDispatcher->dispatch(new CommentCreatedEvent(
+                        table: $fieldArray['foreign_table'],
+                        recordUid: (int) $fieldArray['foreign_uid'],
+                        commentUid: (int) $resolvedId,
+                        authorUid: (int) $backendUser->getUserId(),
+                    ));
+                }
+            }
+
+            // Dispatch CommentResolvedEvent when a comment is resolved
+            if ('update' === $status && array_key_exists('resolved_date', $fieldArray) && (int) $fieldArray['resolved_date'] > 0 && MathUtility::canBeInterpretedAsInteger($id)) {
+                $comment = $this->commentRepository->findByUid((int) $id);
+                if ($comment && isset($comment['foreign_table'], $comment['foreign_uid'])) {
+                    /** @var BackendUserAuthentication $resolvedBackendUser */
+                    $resolvedBackendUser = $GLOBALS['BE_USER'];
+                    $this->eventDispatcher->dispatch(new CommentResolvedEvent(
+                        table: $comment['foreign_table'],
+                        recordUid: (int) $comment['foreign_uid'],
+                        commentUid: (int) $id,
+                        resolvedByUid: (int) $resolvedBackendUser->getUserId(),
+                    ));
+                }
+            }
+
             /*
             * This is a workaround to update the relation of comments to the content planner record.
             * The relation is not updated correctly by the DataHandler.

--- a/Documentation/DeveloperCorner/Events.rst
+++ b/Documentation/DeveloperCorner/Events.rst
@@ -92,9 +92,81 @@ Note that ``$newStatus`` may be ``null`` when a status is cleared from a record.
           identifier: 'my-extension/status-change'
 
 
+CommentCreatedEvent
+====================
+
+This event is dispatched after a new comment has been saved to the database. This includes both root comments and replies. Use it for notifications, activity logging, or integration with external systems.
+
+The ``table`` property refers to the record being commented on (e.g. ``pages``), not the comment table itself.
+
+..  code-block:: php
+    :caption: Classes/EventListener/CommentNotificationListener.php
+
+    <?php
+    namespace MyVendor\MyExtension\EventListener;
+
+    use Xima\XimaTypo3ContentPlanner\Event\CommentCreatedEvent;
+
+    final class CommentNotificationListener
+    {
+        public function __invoke(CommentCreatedEvent $event): void
+        {
+            $table = $event->getTable();           // e.g. 'pages'
+            $recordUid = $event->getRecordUid();   // UID of the commented record
+            $commentUid = $event->getCommentUid(); // UID of the new comment
+            $authorUid = $event->getAuthorUid();   // UID of the backend user
+
+            // Example: Send Slack notification
+        }
+    }
+
+..  code-block:: yaml
+    :caption: Configuration/Services.yaml
+
+    MyVendor\MyExtension\EventListener\CommentNotificationListener:
+      tags:
+        - name: event.listener
+          identifier: 'my-extension/comment-notification'
+
+CommentResolvedEvent
+=====================
+
+This event is dispatched when a comment is marked as resolved. It is **not** dispatched when a comment is reopened (unresolved).
+
+..  code-block:: php
+    :caption: Classes/EventListener/CommentResolvedListener.php
+
+    <?php
+    namespace MyVendor\MyExtension\EventListener;
+
+    use Xima\XimaTypo3ContentPlanner\Event\CommentResolvedEvent;
+
+    final class CommentResolvedListener
+    {
+        public function __invoke(CommentResolvedEvent $event): void
+        {
+            $table = $event->getTable();               // e.g. 'pages'
+            $recordUid = $event->getRecordUid();       // UID of the commented record
+            $commentUid = $event->getCommentUid();     // UID of the resolved comment
+            $resolvedByUid = $event->getResolvedByUid(); // UID of the resolving user
+
+            // Example: Log resolution for audit trail
+        }
+    }
+
+..  code-block:: yaml
+    :caption: Configuration/Services.yaml
+
+    MyVendor\MyExtension\EventListener\CommentResolvedListener:
+      tags:
+        - name: event.listener
+          identifier: 'my-extension/comment-resolved'
+
 ..  seealso::
 
     View the sources on GitHub:
 
     -   `PrepareStatusSelectionEvent <https://github.com/xima-media/xima-typo3-content-planner/blob/main/Classes/Event/PrepareStatusSelectionEvent.php>`__
     -   `StatusChangeEvent <https://github.com/xima-media/xima-typo3-content-planner/blob/main/Classes/Event/StatusChangeEvent.php>`__
+    -   `CommentCreatedEvent <https://github.com/xima-media/xima-typo3-content-planner/blob/main/Classes/Event/CommentCreatedEvent.php>`__
+    -   `CommentResolvedEvent <https://github.com/xima-media/xima-typo3-content-planner/blob/main/Classes/Event/CommentResolvedEvent.php>`__

--- a/Tests/Unit/Event/CommentCreatedEventTest.php
+++ b/Tests/Unit/Event/CommentCreatedEventTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Tests\Unit\Event;
+
+use PHPUnit\Framework\TestCase;
+use Xima\XimaTypo3ContentPlanner\Event\CommentCreatedEvent;
+
+
+/**
+ * CommentCreatedEventTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+
+final class CommentCreatedEventTest extends TestCase
+{
+    public function testGetters(): void
+    {
+        $event = new CommentCreatedEvent(
+            table: 'pages',
+            recordUid: 42,
+            commentUid: 7,
+            authorUid: 3,
+        );
+
+        self::assertSame('pages', $event->getTable());
+        self::assertSame(42, $event->getRecordUid());
+        self::assertSame(7, $event->getCommentUid());
+        self::assertSame(3, $event->getAuthorUid());
+    }
+}

--- a/Tests/Unit/Event/CommentCreatedEventTest.php
+++ b/Tests/Unit/Event/CommentCreatedEventTest.php
@@ -16,14 +16,12 @@ namespace Xima\XimaTypo3ContentPlanner\Tests\Unit\Event;
 use PHPUnit\Framework\TestCase;
 use Xima\XimaTypo3ContentPlanner\Event\CommentCreatedEvent;
 
-
 /**
  * CommentCreatedEventTest.
  *
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */
-
 final class CommentCreatedEventTest extends TestCase
 {
     public function testGetters(): void

--- a/Tests/Unit/Event/CommentResolvedEventTest.php
+++ b/Tests/Unit/Event/CommentResolvedEventTest.php
@@ -16,14 +16,12 @@ namespace Xima\XimaTypo3ContentPlanner\Tests\Unit\Event;
 use PHPUnit\Framework\TestCase;
 use Xima\XimaTypo3ContentPlanner\Event\CommentResolvedEvent;
 
-
 /**
  * CommentResolvedEventTest.
  *
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */
-
 final class CommentResolvedEventTest extends TestCase
 {
     public function testGetters(): void

--- a/Tests/Unit/Event/CommentResolvedEventTest.php
+++ b/Tests/Unit/Event/CommentResolvedEventTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Tests\Unit\Event;
+
+use PHPUnit\Framework\TestCase;
+use Xima\XimaTypo3ContentPlanner\Event\CommentResolvedEvent;
+
+
+/**
+ * CommentResolvedEventTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+
+final class CommentResolvedEventTest extends TestCase
+{
+    public function testGetters(): void
+    {
+        $event = new CommentResolvedEvent(
+            table: 'pages',
+            recordUid: 42,
+            commentUid: 7,
+            resolvedByUid: 5,
+        );
+
+        self::assertSame('pages', $event->getTable());
+        self::assertSame(42, $event->getRecordUid());
+        self::assertSame(7, $event->getCommentUid());
+        self::assertSame(5, $event->getResolvedByUid());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
 		"ext-filter": "*",
 		"ext-libxml": "*",
 		"doctrine/dbal": "^4.0",
+		"psr/event-dispatcher": "^1.0",
 		"psr/http-message": "^1.0 || ^2.0",
 		"psr/http-server-handler": "^1.0.2",
 		"psr/http-server-middleware": "^1.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "50dc95db367acfbf8703033fb52ea3e2",
+    "content-hash": "2e1b2cb97f6a0a6d930cabf41cce72a3",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
## Summary

- Add `CommentCreatedEvent` dispatched after a new comment is saved
- Add `CommentResolvedEvent` dispatched when a comment is marked as resolved
- Enables integrations like email notifications, Slack webhooks, or logging

## Changes

- `CommentCreatedEvent.php` — carries table, recordUid, commentUid, authorUid
- `CommentResolvedEvent.php` — carries table, recordUid, commentUid, resolvedByUid
- `DataHandlerHook.php` — add `EventDispatcherInterface`, dispatch events in `processDatamap_afterDatabaseOperations`
- `CommentCreatedEventTest.php` — unit test for getter methods
- `CommentResolvedEventTest.php` — unit test for getter methods