### PR TITLE
fix: comment dropdown broken on TYPO3 v14

### DIFF
--- a/Resources/Private/Templates/Default/Comments.html
+++ b/Resources/Private/Templates/Default/Comments.html
@@ -18,10 +18,10 @@
                 </select>
                 <f:if condition="{shareUrl}">
                     <div class="dropdown">
-                        <a href="#" class="btn btn-default btn-sm" data-bs-toggle="dropdown"
-                           aria-expanded="false" title="">
+                        <button type="button" class="btn btn-default btn-sm dropdown-toggle dropdown-toggle-no-chevron" data-bs-toggle="dropdown"
+                                aria-expanded="false">
                             <core:icon identifier="actions-menu-alternative" size="small"/>
-                        </a>
+                        </button>
                         <ul class="dropdown-menu dropdown-menu-end">
                             <li>
                                 <a class="dropdown-item" data-share-modal-uri="{shareUrl}">
@@ -77,10 +77,10 @@
                                 </a>
                             </small>
                             <div class="btn-group content-planner-comment__actions">
-                                <a href="#" class="btn btn-default" data-bs-toggle="dropdown"
-                                aria-expanded="false" title="">
+                                <button type="button" class="btn btn-default dropdown-toggle dropdown-toggle-no-chevron" data-bs-toggle="dropdown"
+                                        aria-expanded="false">
                                     <core:icon identifier="actions-menu-alternative" size="small" title="Actions"/>
-                                </a>
+                                </button>
                                 <ul class="dropdown-menu">
                                     <f:if condition="{record.canCurrentUserEdit}">
                                     <li>

--- a/Resources/Public/Css/Comments.css
+++ b/Resources/Public/Css/Comments.css
@@ -79,7 +79,7 @@
 }
 
 /* Actions */
-.content-planner-comment__actions > a {
+.content-planner-comment__actions > button {
     font-size: smaller;
     min-height: 22px;
     padding: 0 6px;
@@ -87,9 +87,6 @@
     border-radius: 0;
 }
 
-.content-planner-comment__actions a:hover {
-    cursor: pointer;
-}
 
 /* ==========================================================================
    Comment List

--- a/docs/issues/v14-dropdown-queryselector-bug.md
+++ b/docs/issues/v14-dropdown-queryselector-bug.md
@@ -1,0 +1,77 @@
+# Bug: Comment dropdown broken on TYPO3 v14
+
+## Status: Fixed
+
+## Problem
+
+The comment action dropdown (Edit, Resolve, Share, Delete) does not open on TYPO3 v14. A JavaScript error prevents interaction.
+
+## Error
+
+```
+dropdown.js:13 Uncaught SyntaxError: Failed to execute 'querySelector' on 'Document': '#' is not a valid selector.
+    at f.getMenu (dropdown.js:13:3641)
+    at HTMLDocument.<anonymous> (dropdown.js:13:3056)
+```
+
+## Root Cause (two issues)
+
+### 1. querySelector error
+
+TYPO3 v14's `dropdown.js` has a `getMenu()` method that reads the `href` attribute as a CSS selector:
+
+```javascript
+getMenu(e) {
+  const r = e.getAttribute("href");
+  return r?.startsWith("#") ? document.querySelector(r) : // <-- fails on href="#"
+         e.nextElementSibling?.matches(".dropdown-menu") ? e.nextElementSibling : ...
+}
+```
+
+When `href="#"`, `document.querySelector('#')` throws an uncaught `SyntaxError`. The fallback is never reached.
+
+### 2. Popover API positioning
+
+TYPO3 v14 completely replaced Bootstrap's Dropdown+Popper.js with the native **Popover API**. The `dropdown.js` converts all `data-bs-toggle="dropdown"` elements:
+- Adds `popover` attribute to the `.dropdown-menu`
+- Adds `popovertarget` to the toggle button
+
+Popovers render in the browser's **top layer** (viewport-relative, not parent-relative). TYPO3 v14 positions them using **CSS Anchor Positioning**:
+
+```css
+.dropdown-toggle { anchor-name: --dropdown; }
+.dropdown-menu   { position-anchor: --dropdown; position-area: block-end span-inline-end; }
+```
+
+Our toggle buttons were missing the `dropdown-toggle` class, so no anchor was established and the popover floated to the viewport's default position.
+
+## Fix Applied
+
+### Files changed
+
+- **`Resources/Private/Templates/Default/Comments.html`**
+  - Changed `<a href="#">` to `<button type="button">` (fixes querySelector error)
+  - Added `dropdown-toggle dropdown-toggle-no-chevron` classes (enables CSS anchor positioning on v14)
+
+- **`Resources/Public/Css/Comments.css`**
+  - Updated `.content-planner-comment__actions > a` selector to `> button`
+  - Removed manual `!important` positioning overrides (no longer needed)
+
+### Why this works
+
+- **v13:** Bootstrap's Dropdown class + Popper.js handles positioning. `dropdown-toggle` is the standard Bootstrap class for dropdown triggers.
+- **v14:** The `dropdown-toggle` class gets `anchor-name: --dropdown` from TYPO3's backend CSS. The `.dropdown-menu` references this anchor via `position-anchor: --dropdown` and positions itself at `block-end span-inline-end` (below the button, aligned right).
+
+## Reproduction
+
+1. `ddev install 14`
+2. Open any page with Content Planner status
+3. Open the comments panel
+4. Click the three-dot action button on any comment
+5. ~~Observe: dropdown does not open~~ Dropdown opens and positions correctly relative to the button
+
+Works correctly on both TYPO3 v13 and v14.
+
+## Priority
+
+Medium — v13 is the primary supported LTS version, v14 support is secondary.


### PR DESCRIPTION
## Summary

- Fix comment action dropdowns not opening on TYPO3 v14 due to `querySelector('#')` error
- Fix dropdown positioning by using TYPO3 v14's CSS Anchor Positioning via `dropdown-toggle` class

## Root Cause

TYPO3 v14 replaced Bootstrap Dropdown+Popper.js with the native Popover API. Two issues caused the breakage:

1. `<a href="#">` triggers `document.querySelector('#')` in v14's `getMenu()` — invalid selector
2. Missing `dropdown-toggle` class prevented CSS Anchor Positioning (`anchor-name: --dropdown`)

## Changes

- `Resources/Private/Templates/Default/Comments.html` — replace `<a href="#">` with `<button type="button" class="dropdown-toggle dropdown-toggle-no-chevron">` for both filter and comment action dropdowns
- `Resources/Public/Css/Comments.css` — update selector from `> a` to `> button`, remove redundant hover rule
- `docs/issues/v14-dropdown-queryselector-bug.md` — detailed bug analysis and fix documentation

## Compatibility

Works on both TYPO3 v13 (Bootstrap Dropdown + Popper.js) and v14 (Popover API + CSS Anchor Positioning).