### PR TITLE
feat: add reply collapse/expand toggle with user preference

### DIFF
--- a/Classes/Controller/RecordController.php
+++ b/Classes/Controller/RecordController.php
@@ -190,10 +190,14 @@ class RecordController extends ActionController
             return new JsonResponse(['error' => 'Invalid setting key'], 400);
         }
 
+        if (!in_array($value, ['0', '1'], true)) {
+            return new JsonResponse(['error' => 'Invalid setting value'], 400);
+        }
+
         /** @var BackendUserAuthentication $backendUser */
         $backendUser = $GLOBALS['BE_USER'];
         $contentPlannerSettings = $backendUser->uc['contentPlanner'] ?? [];
-        $contentPlannerSettings[$key] = (bool) $value;
+        $contentPlannerSettings[$key] = '1' === $value;
         $backendUser->uc['contentPlanner'] = $contentPlannerSettings;
         $backendUser->writeUC();
 

--- a/Classes/Controller/RecordController.php
+++ b/Classes/Controller/RecordController.php
@@ -30,6 +30,7 @@ use Xima\XimaTypo3ContentPlanner\Utility\Routing\UrlUtility;
 use Xima\XimaTypo3ContentPlanner\Utility\Security\PermissionUtility;
 
 use function array_key_exists;
+use function in_array;
 use function is_array;
 
 /**
@@ -40,6 +41,8 @@ use function is_array;
  */
 class RecordController extends ActionController
 {
+    private const ALLOWED_USER_SETTINGS = ['repliesExpanded'];
+
     public function __construct(
         private readonly RecordRepository $recordRepository,
         private readonly CommentRepository $commentRepository,
@@ -107,6 +110,10 @@ class RecordController extends ActionController
         $sortComments = $request->getQueryParams()['sortComments'] ?? 'DESC';
         $showResolvedComments = (bool) ($request->getQueryParams()['showResolvedComments'] ?? false);
 
+        /** @var BackendUserAuthentication $backendUser */
+        $backendUser = $GLOBALS['BE_USER'];
+        $repliesExpanded = (bool) ($backendUser->uc['contentPlanner']['repliesExpanded'] ?? false);
+
         $comments = $this->commentRepository->findAllByRecord($recordId, $recordTable, sortDirection: $sortComments, showResolved: $showResolvedComments);
 
         $result = ViewUtility::render(
@@ -115,6 +122,7 @@ class RecordController extends ActionController
                 'comments' => $comments,
                 'id' => $recordId,
                 'table' => $recordTable,
+                'repliesExpanded' => $repliesExpanded,
                 'newCommentUri' => PermissionUtility::canCreateComment() ? UrlUtility::getNewCommentUrl($recordTable, $recordId) : '',
                 'shareUrl' => UrlUtility::getShareUrl($recordTable, $recordId),
                 'filter' => [
@@ -171,6 +179,25 @@ class RecordController extends ActionController
         $result .= AssetUtility::getJsTag('EXT:'.Configuration::EXT_KEY.'/Resources/Public/JavaScript/assignee-select.js', ['nonce' => $this->requestId->nonce]);
 
         return new JsonResponse(['result' => $result]);
+    }
+
+    public function userSettingAction(ServerRequestInterface $request): JsonResponse
+    {
+        $key = $request->getQueryParams()['key'] ?? '';
+        $value = $request->getQueryParams()['value'] ?? '';
+
+        if (!in_array($key, self::ALLOWED_USER_SETTINGS, true)) {
+            return new JsonResponse(['error' => 'Invalid setting key'], 400);
+        }
+
+        /** @var BackendUserAuthentication $backendUser */
+        $backendUser = $GLOBALS['BE_USER'];
+        $contentPlannerSettings = $backendUser->uc['contentPlanner'] ?? [];
+        $contentPlannerSettings[$key] = (bool) $value;
+        $backendUser->uc['contentPlanner'] = $contentPlannerSettings;
+        $backendUser->writeUC();
+
+        return new JsonResponse(['key' => $key, 'value' => $contentPlannerSettings[$key]]);
     }
 
     /**

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -28,4 +28,8 @@ return [
         'path' => '/content-planner/message',
         'target' => Xima\XimaTypo3ContentPlanner\Controller\ProxyController::class.'::messageAction',
     ],
+    'ximatypo3contentplanner_usersetting' => [
+        'path' => '/content-planner/user-setting',
+        'target' => Xima\XimaTypo3ContentPlanner\Controller\RecordController::class.'::userSettingAction',
+    ],
 ];

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -400,6 +400,14 @@
 				<source>Reply</source>
 				<target>Antworten</target>
 			</trans-unit>
+			<trans-unit id="comment.actions.replies.expand">
+				<source>Expand replies</source>
+				<target>Antworten ausklappen</target>
+			</trans-unit>
+			<trans-unit id="comment.actions.replies.collapse">
+				<source>Collapse replies</source>
+				<target>Antworten einklappen</target>
+			</trans-unit>
 			<trans-unit id="comment.badge.reply">
 				<source>Reply</source>
 				<target>Antwort</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -243,6 +243,12 @@
 			<trans-unit id="comment.actions.reply">
 				<source>Reply</source>
 			</trans-unit>
+			<trans-unit id="comment.actions.replies.expand">
+				<source>Expand replies</source>
+			</trans-unit>
+			<trans-unit id="comment.actions.replies.collapse">
+				<source>Collapse replies</source>
+			</trans-unit>
 			<trans-unit id="comment.badge.reply">
 				<source>Reply</source>
 			</trans-unit>

--- a/Resources/Private/Partials/Comment.html
+++ b/Resources/Private/Partials/Comment.html
@@ -119,7 +119,7 @@
             </a>
             <div class="{f:if(condition: '{repliesExpanded}', then: 'collapse show', else: 'collapse')} content-planner-comment-replies" id="replies-{comment.data.uid}">
                 <f:for each="{comment.replies}" as="reply">
-                    <f:render partial="Comment" arguments="{comment: reply, id: id, table: table, isReply: 1}" />
+                    <f:render partial="Comment" arguments="{comment: reply, id: id, table: table, isReply: 1, repliesExpanded: repliesExpanded}" />
                 </f:for>
                 <button type="button" class="btn btn-default btn-sm content-planner-comment-reply-inline"
                         data-id="{id}" data-table="{table}" data-reply-comment-uri="{comment.replyUri}">

--- a/Resources/Private/Partials/Comment.html
+++ b/Resources/Private/Partials/Comment.html
@@ -111,13 +111,13 @@
         <f:if condition="{comment.replies}">
             <a class="content-planner-comment-replies-toggle"
                data-bs-toggle="collapse" href="#replies-{comment.data.uid}"
-               role="button" aria-expanded="false" aria-controls="replies-{comment.data.uid}">
+               role="button" aria-expanded="{f:if(condition: '{repliesExpanded}', then: 'true', else: 'false')}" aria-controls="replies-{comment.data.uid}">
                 <core:icon identifier="actions-chevron-right" size="small"/>
                 <span><f:if condition="{comment.replyCount} == 1"><f:then><f:translate key="comment.reply.toggle" extensionName="XimaTypo3ContentPlanner"
                             arguments="{0: '{comment.lastReplyTimeAgo}'}"/></f:then><f:else><f:translate key="comment.replies.toggle" extensionName="XimaTypo3ContentPlanner"
                             arguments="{0: '{comment.replyCount}', 1: '{comment.lastReplyTimeAgo}'}"/></f:else></f:if></span>
             </a>
-            <div class="collapse content-planner-comment-replies" id="replies-{comment.data.uid}">
+            <div class="{f:if(condition: '{repliesExpanded}', then: 'collapse show', else: 'collapse')} content-planner-comment-replies" id="replies-{comment.data.uid}">
                 <f:for each="{comment.replies}" as="reply">
                     <f:render partial="Comment" arguments="{comment: reply, id: id, table: table, isReply: 1}" />
                 </f:for>

--- a/Resources/Private/Templates/Default/Comments.html
+++ b/Resources/Private/Templates/Default/Comments.html
@@ -1,7 +1,7 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
     data-namespace-typo3-fluid="true">
 
-<div id="content-planner-comment-list" class="content-planner-comment-list">
+<div id="content-planner-comment-list" class="content-planner-comment-list" data-replies-expanded="{f:if(condition: '{repliesExpanded}', then: '1', else: '0')}">
     <f:if condition="{comments -> f:count()} || {filter.resolvedCount}">
         <form id="content-planner-comment-filter" class="content-planner-comment-filter" data-table="{table}" data-id="{id}">
             <div class="form-sort">
@@ -29,6 +29,25 @@
                                                 extensionName="XimaTypo3ContentPlanner"/>
                                 </a>
                             </li>
+                            <li><hr class="dropdown-divider"/></li>
+                            <li>
+                                <f:if condition="{repliesExpanded}">
+                                    <f:then>
+                                        <a class="dropdown-item" data-toggle-replies-expanded="0">
+                                            <core:icon identifier="actions-chevron-up" size="small"/>
+                                            <f:translate key="comment.actions.replies.collapse"
+                                                        extensionName="XimaTypo3ContentPlanner"/>
+                                        </a>
+                                    </f:then>
+                                    <f:else>
+                                        <a class="dropdown-item" data-toggle-replies-expanded="1">
+                                            <core:icon identifier="actions-chevron-down" size="small"/>
+                                            <f:translate key="comment.actions.replies.expand"
+                                                        extensionName="XimaTypo3ContentPlanner"/>
+                                        </a>
+                                    </f:else>
+                                </f:if>
+                            </li>
                         </ul>
                     </div>
                 </f:if>
@@ -50,7 +69,7 @@
     <f:if condition="{comments -> f:count()}">
         <f:then>
             <f:for each="{comments}" as="record">
-                <f:render partial="Comment" arguments="{comment: record, id: id, table: table, isReply: 0, showRecordInfo: 0}" />
+                <f:render partial="Comment" arguments="{comment: record, id: id, table: table, isReply: 0, showRecordInfo: 0, repliesExpanded: repliesExpanded}" />
             </f:for>
         </f:then>
         <f:else>

--- a/Resources/Private/Templates/Default/Comments.html
+++ b/Resources/Private/Templates/Default/Comments.html
@@ -33,18 +33,18 @@
                             <li>
                                 <f:if condition="{repliesExpanded}">
                                     <f:then>
-                                        <a class="dropdown-item" data-toggle-replies-expanded="0">
+                                        <button type="button" class="dropdown-item" data-toggle-replies-expanded="0">
                                             <core:icon identifier="actions-chevron-up" size="small"/>
                                             <f:translate key="comment.actions.replies.collapse"
                                                         extensionName="XimaTypo3ContentPlanner"/>
-                                        </a>
+                                        </button>
                                     </f:then>
                                     <f:else>
-                                        <a class="dropdown-item" data-toggle-replies-expanded="1">
+                                        <button type="button" class="dropdown-item" data-toggle-replies-expanded="1">
                                             <core:icon identifier="actions-chevron-down" size="small"/>
                                             <f:translate key="comment.actions.replies.expand"
                                                         extensionName="XimaTypo3ContentPlanner"/>
-                                        </a>
+                                        </button>
                                     </f:else>
                                 </f:if>
                             </li>

--- a/Resources/Public/JavaScript/comments-reload-content.js
+++ b/Resources/Public/JavaScript/comments-reload-content.js
@@ -23,6 +23,7 @@ class CommentsReloadContent {
 
   initEventListeners() {
     this.initCommentHover()
+    this.initRepliesToggle()
 
     document.querySelector('form#content-planner-comment-filter')?.addEventListener('change', (event) => {
       event.preventDefault()
@@ -59,6 +60,32 @@ class CommentsReloadContent {
       })
       this.replyDelegateInitialized = true
     }
+  }
+
+  initRepliesToggle() {
+    document.querySelectorAll('[data-toggle-replies-expanded]').forEach(item => {
+      item.addEventListener('click', event => {
+        event.preventDefault()
+        const newValue = item.getAttribute('data-toggle-replies-expanded')
+
+        new AjaxRequest(TYPO3.settings.ajaxUrls.ximatypo3contentplanner_usersetting)
+          .withQueryArguments({key: 'repliesExpanded', value: newValue})
+          .get()
+          .then(() => {
+            const filterForm = document.querySelector('form#content-planner-comment-filter')
+            if (filterForm) {
+              const url = TYPO3.settings.ajaxUrls.ximatypo3contentplanner_comments
+              const table = filterForm.getAttribute('data-table')
+              const uid = filterForm.getAttribute('data-id')
+              this.loadComments(url, table, uid)
+            }
+          })
+          .catch((error) => {
+            console.error('Failed to save user setting:', error)
+            top.TYPO3.Notification.error('Error', 'Failed to save setting.')
+          })
+      })
+    })
   }
 
   initCommentHover() {


### PR DESCRIPTION
## Summary

- Add toggle option in comment modal action dropdown to expand/collapse all reply threads
- Persist user preference in `BE_USER->uc['contentPlanner']['repliesExpanded']` via new AJAX route
- Replies render with correct initial state based on saved preference

## Changes

- `Classes/Controller/RecordController.php` - Add `userSettingAction` with whitelist validation, pass `repliesExpanded` from `uc` in `commentsAction`
- `Configuration/Backend/AjaxRoutes.php` - Add `ximatypo3contentplanner_usersetting` route
- `Resources/Private/Templates/Default/Comments.html` - Add dropdown menu item (expand/collapse), `data-replies-expanded` attribute, pass variable to partial
- `Resources/Private/Partials/Comment.html` - Conditional `aria-expanded` and `collapse show` class based on preference
- `Resources/Public/JavaScript/comments-reload-content.js` - Add `initRepliesToggle()` handler with AJAX save + comment reload
- `Resources/Private/Language/locallang.xlf` - Add EN labels
- `Resources/Private/Language/de.locallang.xlf` - Add DE translations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expand/collapse toggle controls for comment replies in the comments panel (now available in the share menu).
  * Reply expansion state is saved to your preferences and persists across sessions.
  * Toggling replies updates the UI immediately by reloading comments and respects accessibility attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->