### PR TITLE
fix: align status bar with content element border-radius in v14

### DIFF
--- a/Classes/Service/ContentModifier/WebLayoutModifier.php
+++ b/Classes/Service/ContentModifier/WebLayoutModifier.php
@@ -66,7 +66,7 @@ class WebLayoutModifier extends AbstractModifier implements ModifierInterface
                 continue;
             }
             $statusColor = Configuration\Colors::get($status->getColor());
-            $styling[] = '.t3-page-ce[data-uid="'.$record['uid'].'"]:before { content: "";display:block;box-shadow:var(--pagemodule-element-box-shadow);padding:.5em;border-left: 5px solid '.$statusColor.';border-radius: 5px 5px 0 0;background-color:'.$statusColor.'; }';
+            $styling[] = '.t3-page-ce[data-uid="'.$record['uid'].'"] .t3-page-ce-element:before { content: "";display:block;padding:.5em;border-left: 5px solid '.$statusColor.';background-color:'.$statusColor.'; }';
         }
 
         return '<style>'.implode(' ', $styling).'</style>';


### PR DESCRIPTION
## Summary

- Fix visual glitch where the content element status bar had square corners clashing with TYPO3 v14's rounded content elements
- Move CSS pseudo-element from `.t3-page-ce` to `.t3-page-ce-element` so it respects the parent's `overflow: hidden` and `border-radius`

## Changes

- `Classes/Service/ContentModifier/WebLayoutModifier.php` - Target `.t3-page-ce-element:before` instead of `.t3-page-ce:before`, remove redundant `box-shadow` and `border-radius`