### PR TITLE
chore(deps): pin TYPO3 v14 dependencies to ^14.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,20 +24,20 @@
 		"psr/http-server-handler": "^1.0.2",
 		"psr/http-server-middleware": "^1.0.2",
 		"symfony/console": "^7.0 || ^8.0",
-		"typo3/cms-backend": "^13.4 || ^14.0",
-		"typo3/cms-beuser": "^13.4 || ^14.0",
-		"typo3/cms-core": "^13.4 || ^14.0",
-		"typo3/cms-dashboard": "^13.4 || ^14.0",
-		"typo3/cms-extbase": "^13.4 || ^14.0",
-		"typo3/cms-fluid": "^13.4 || ^14.0",
+		"typo3/cms-backend": "^13.4 || ^14.3",
+		"typo3/cms-beuser": "^13.4 || ^14.3",
+		"typo3/cms-core": "^13.4 || ^14.3",
+		"typo3/cms-dashboard": "^13.4 || ^14.3",
+		"typo3/cms-extbase": "^13.4 || ^14.3",
+		"typo3/cms-fluid": "^13.4 || ^14.3",
 		"typo3fluid/fluid": "^4.2 || ^5.0"
 	},
 	"require-dev": {
 		"eliashaeussler/version-bumper": "^2.4 || ^3.0 || ^4.0",
 		"helhum/typo3-console": "^8.3.1",
 		"phpunit/phpunit": "^10.2 || ^11.0 || ^12.0",
-		"typo3/cms-base-distribution": "^13.4 || ^14.0",
-		"typo3/cms-lowlevel": "^13.4 || ^14.0"
+		"typo3/cms-base-distribution": "^13.4 || ^14.3",
+		"typo3/cms-lowlevel": "^13.4 || ^14.3"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ca730200015c70ff48a33dda3619cd6",
+    "content-hash": "e1892f11af3a36cd1b91b9cf5218f7bd",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
## Summary

- Update minimum supported TYPO3 v14 version from `^14.0` to `^14.3` across all required and dev TYPO3 packages
- Refresh `composer.lock` content hash

## Changes

- `composer.json` — bump `typo3/cms-*` constraints (backend, beuser, core, dashboard, extbase, fluid, base-distribution, lowlevel) to `^13.4 || ^14.3`
- `composer.lock` — updated content hash