### PR TITLE
chore: remove obsolete PHP constraint from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,8 +7,5 @@
 	"ignorePaths": [
 		"package-lock.json",
 		"Tests/Acceptance/Fixtures/**"
-	],
-	"constraints": {
-		"php": ">=8.2"
-	}
+	]
 }


### PR DESCRIPTION
## Summary

- Remove redundant `constraints.php` block from renovate configuration

The PHP version requirement is already declared in `composer.json`, which Renovate reads automatically. Keeping a separate constraint here only risks the two values drifting apart.

## Changes

- `renovate.json` — drop the `constraints` object

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration by removing version constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->