### PR TITLE
chore(ci): switch to konradmichalik/reusable-github-actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   ter-publish:
-    uses: maikschneider/reusable-workflows/.github/workflows/release.yml@main
+    uses: konradmichalik/reusable-github-actions/.github/workflows/release-typo3.yml@main
     secrets:
       typo3-api-token: ${{ secrets.TYPO3_API_TOKEN }}
     with:


### PR DESCRIPTION
## Summary

- Switch the release workflow to use `konradmichalik/reusable-github-actions/.github/workflows/release-typo3.yml@main` instead of `maikschneider/reusable-workflows/.github/workflows/release.yml@main`.

## Changes

- `.github/workflows/release.yml` — point reusable workflow `uses:` to the new source.