### PR TITLE
fix: register user settings via TCA on TYPO3 v14.2+

### DIFF
--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -15,6 +15,7 @@ namespace Xima\XimaTypo3ContentPlanner;
 
 use TYPO3\CMS\Backend\Controller\Page\TreeController as BackendTreeController;
 use TYPO3\CMS\Backend\Form\FormDataProvider\EvaluateDisplayConditions;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use Xima\XimaTypo3ContentPlanner\Controller\TreeController;
 use Xima\XimaTypo3ContentPlanner\Form\FormDataProvider\ContentPlannerFieldsReadOnly;
 use Xima\XimaTypo3ContentPlanner\Hooks\DataHandlerHook;
@@ -112,17 +113,43 @@ class Configuration
 
     public static function registerUserSettings(): void
     {
+        $label = 'LLL:EXT:'.self::EXT_KEY.'/Resources/Private/Language/locallang_db.xlf:be_users.tx_ximatypo3contentplanner_hide';
+        $description = 'LLL:EXT:'.self::EXT_KEY.'/Resources/Private/Language/locallang_db.xlf:be_users.tx_ximatypo3contentplanner_hide.description';
+        $tabLabel = 'LLL:EXT:'.self::EXT_KEY.'/Resources/Private/Language/locallang_db.xlf:content_planner';
+        $showitemAddition = '--div--;'.$tabLabel.',tx_ximatypo3contentplanner_hide';
+
+        // TYPO3 v14.2+ migrated user settings to TCA. The legacy
+        // $GLOBALS['TYPO3_USER_SETTINGS'] format without a 'config' key
+        // triggers a null pointer when opening the user settings module
+        // on v14.3. See https://docs.typo3.org/permalink/t3coreapi:user-settings-extending-migration
+        // @phpstan-ignore-next-line function.alreadyNarrowedType (kept for TYPO3 v13 backward compatibility)
+        if (method_exists(ExtensionManagementUtility::class, 'addUserSetting')) {
+            $GLOBALS['TCA']['be_users']['columns']['user_settings']['columns']['tx_ximatypo3contentplanner_hide'] = [
+                'label' => $label,
+                'description' => $description,
+                'config' => [
+                    'type' => 'check',
+                    'renderType' => 'checkboxToggle',
+                ],
+                'table' => 'be_users',
+            ];
+
+            $existingShowitem = trim($GLOBALS['TCA']['be_users']['columns']['user_settings']['showitem'] ?? '', ", \t\n\r\0\x0B");
+            $GLOBALS['TCA']['be_users']['columns']['user_settings']['showitem'] = '' !== $existingShowitem
+                ? $existingShowitem.','.$showitemAddition
+                : $showitemAddition;
+
+            return;
+        }
+
         $GLOBALS['TYPO3_USER_SETTINGS']['columns']['tx_ximatypo3contentplanner_hide'] = [
-            'label' => 'LLL:EXT:'.self::EXT_KEY.'/Resources/Private/Language/locallang_db.xlf:be_users.tx_ximatypo3contentplanner_hide',
-            'description' => 'LLL:EXT:'.self::EXT_KEY.'/Resources/Private/Language/locallang_db.xlf:be_users.tx_ximatypo3contentplanner_hide.description',
+            'label' => $label,
+            'description' => $description,
             'type' => 'check',
             'table' => 'be_users',
         ];
 
-        $GLOBALS['TYPO3_USER_SETTINGS']['showitem'] .= ',
-            --div--;LLL:EXT:'.self::EXT_KEY.'/Resources/Private/Language/locallang_db.xlf:content_planner,
-                tx_ximatypo3contentplanner_hide,
-        ';
+        $GLOBALS['TYPO3_USER_SETTINGS']['showitem'] .= ','.$showitemAddition;
     }
 
     public static function registerPermissions(): void

--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -134,10 +134,8 @@ class Configuration
                 'table' => 'be_users',
             ];
 
-            $existingShowitem = trim($GLOBALS['TCA']['be_users']['columns']['user_settings']['showitem'] ?? '', ", \t\n\r\0\x0B");
-            $GLOBALS['TCA']['be_users']['columns']['user_settings']['showitem'] = '' !== $existingShowitem
-                ? $existingShowitem.','.$showitemAddition
-                : $showitemAddition;
+            $GLOBALS['TCA']['be_users']['columns']['user_settings']['showitem']
+                = ($GLOBALS['TCA']['be_users']['columns']['user_settings']['showitem'] ?? '').','.$showitemAddition;
 
             return;
         }


### PR DESCRIPTION
## Summary

Fixes #220 — opening the user settings module on TYPO3 v14.3 throws a null pointer exception because the legacy `$GLOBALS['TYPO3_USER_SETTINGS']` registration format omits the `config` key now expected by the TCA-based user settings schema introduced in v14.2.

- On TYPO3 v14.2+ (detected via `method_exists(ExtensionManagementUtility::class, 'addUserSetting')`), the field is now registered directly on `$GLOBALS['TCA']['be_users']['columns']['user_settings']` with a proper `config` wrapper (`type: check`, `renderType: checkboxToggle`).
- On TYPO3 v13, the legacy `$GLOBALS['TYPO3_USER_SETTINGS']` registration is kept as fallback.
- The custom `--div--` tab for the Content Planner section is preserved on both branches.

References: [User settings extending migration (TYPO3 docs)](https://docs.typo3.org/permalink/t3coreapi:user-settings-extending-migration)

## Test plan

- [x] `ddev cgl lint` — clean
- [x] `ddev cgl sca:php` (PHPStan level 6) — clean
- [x] `ddev composer test` — 90 tests / 187 assertions pass
- [ ] Manual: open user settings module on TYPO3 v14.3 backend with extension installed — no error, "Content Planner" tab visible with toggle
- [ ] Manual: open user settings module on TYPO3 v13 backend — tab and toggle still rendered, value persists