### PR TITLE
chore(ci): whitelist TYPO3 v14-only symbols for composer-require-checker

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -1,0 +1,12 @@
+{
+	"symbol-whitelist": [
+		"TYPO3\\CMS\\Backend\\Controller\\Event\\AfterFileStorageTreeItemsPreparedEvent",
+		"TYPO3\\CMS\\Backend\\Template\\Components\\ActionGroup",
+		"TYPO3\\CMS\\Core\\SystemResource\\Publishing\\SystemResourcePublisherInterface",
+		"TYPO3\\CMS\\Core\\SystemResource\\Publishing\\UriGenerationOptions",
+		"TYPO3\\CMS\\Core\\SystemResource\\SystemResourceFactory",
+		"TYPO3\\CMS\\Dashboard\\Widgets\\WidgetContext",
+		"TYPO3\\CMS\\Dashboard\\Widgets\\WidgetRendererInterface",
+		"TYPO3\\CMS\\Dashboard\\Widgets\\WidgetResult"
+	]
+}


### PR DESCRIPTION
## Summary

- Add project-level `composer-require-checker.json` to whitelist 8 TYPO3 v14-only symbols
- Fixes CGL CI failure where `composer-require-checker check` reports unknown symbols because dependencies resolve to the lowest viable version (v13.4), where these classes do not yet exist

## Background

The extension supports both TYPO3 v13.4 and v14.3 via `^13.4 || ^14.3` constraints. The affected v14-only classes are used behind version guards (e.g. `AfterFileStorageTreeItemsPreparedListener`, `ConfigurableContentStatusWidget`, v14-specific code paths in `AssetUtility` and `ModifyRecordListRecordActionsListener`).

## Whitelisted symbols

- `TYPO3\CMS\Backend\Controller\Event\AfterFileStorageTreeItemsPreparedEvent`
- `TYPO3\CMS\Backend\Template\Components\ActionGroup`
- `TYPO3\CMS\Core\SystemResource\Publishing\SystemResourcePublisherInterface`
- `TYPO3\CMS\Core\SystemResource\Publishing\UriGenerationOptions`
- `TYPO3\CMS\Core\SystemResource\SystemResourceFactory`
- `TYPO3\CMS\Dashboard\Widgets\WidgetContext`
- `TYPO3\CMS\Dashboard\Widgets\WidgetRendererInterface`
- `TYPO3\CMS\Dashboard\Widgets\WidgetResult`

## Changes

- `composer-require-checker.json` - New config with `symbol-whitelist` for the v14-only TYPO3 symbols