### PR TITLE
chore(ddev): refactor DDEV setup and drop legacy v11/v12 support

### DIFF
--- a/.ddev/.setup/scripts/utils.sh
+++ b/.ddev/.setup/scripts/utils.sh
@@ -160,17 +160,16 @@ function post_setup() {
   TYPO3_INSTALL_DB_DBNAME=$DATABASE
 
   _progress " ├─ Setup TYPO3"
-    if [ "$VERSION" == "11" ]; then
-      post_setup_11
-    elif [ "$VERSION" == "12" ]; then
-      post_setup_12
-    elif [ "$VERSION" == "13" ]; then
+    if [ "$VERSION" == "13" ]; then
       post_setup_13
     elif [ "$VERSION" == "14" ]; then
       post_setup_14
     fi
   _done
 
+  _progress " ├─ Setup site configuration"
+    setup_site_config
+  _done
   _progress " ├─ Import data"
     import_xml_data
     import_sql_data
@@ -218,11 +217,7 @@ function setup_environment() {
     mkdir -p "$BASE_PATH/packages/$EXTENSION_KEY"
     chmod 775 -R $BASE_PATH
     export DATABASE="database_$VERSION"
-    if [ "$VERSION" == "11" ]; then
-        export TYPO3_BIN="$BASE_PATH/vendor/bin/typo3cms"
-    else
-        export TYPO3_BIN="$BASE_PATH/vendor/bin/typo3"
-    fi
+    export TYPO3_BIN="$BASE_PATH/vendor/bin/typo3"
     mysql -uroot -proot -e "DROP DATABASE IF EXISTS $DATABASE"
 }
 
@@ -294,6 +289,7 @@ function install_composer_packages() {
     composer req typo3/cms-base-distribution:"^$VERSION" \
             typo3/cms-reports:"^$VERSION" \
             typo3/cms-lowlevel:"^$VERSION" \
+            bk2k/bootstrap-package:'*' \
             $PACKAGE_NAME:'*@dev' \
             test/sitepackage:'*@dev' \
             helhum/typo3-console:'*' \
@@ -327,6 +323,27 @@ function prepare_acceptance_testing() {
 
     $BASE_PATH/vendor/bin/codecept build -c $BASE_PATH/codeception.yml
   _done
+}
+
+# Function to set up site configuration from templates.
+# It copies site config templates and replaces placeholders with actual values.
+function setup_site_config() {
+    local TEMPLATE_DIR="/var/www/html/.ddev/.setup/templates/config"
+    local TARGET_DIR="$BASE_PATH/config"
+
+    if [ ! -d "$TEMPLATE_DIR" ]; then
+        return
+    fi
+
+    # Overwrite site config created by typo3 setup with our templates
+    rm -rf "$TARGET_DIR/sites"
+    cp -r "$TEMPLATE_DIR/sites" "$TARGET_DIR/sites"
+
+    # Replace placeholders in all YAML files
+    find "$TARGET_DIR/sites" -name "*.yaml" -exec sed -i \
+        -e "s/__VERSION__/$VERSION/g" \
+        -e "s/__EXTENSION_NAME__/$EXTENSION_NAME/g" \
+        {} +
 }
 
 # Function to import XML data into TYPO3.
@@ -368,33 +385,6 @@ function import_sql_data() {
           message yellow "No SQL files found in $FIXTURE_DIR. Import will be skipped."
         fi
     done
-}
-
-# Function to perform post-setup tasks for TYPO3 version 11.
-# It sets up TYPO3 by running the installation setup, configuring TYPO3 settings,
-# and modifying configuration files to enable deprecations and adjust base paths.
-function post_setup_11 {
-  $TYPO3_BIN install:setup -n --database-name $DATABASE
-  setup_typo3
-  $TYPO3_BIN configuration:set 'GFX/processor_path_lzw' '/usr/bin/'
-
-  sed -i "/'deprecations'/,/^[[:space:]]*'disabled' => true,/s/'disabled' => true,/'disabled' => false,/" /var/www/html/.Build/$VERSION/public/typo3conf/LocalConfiguration.php
-
-  sed -i -e "s/base: ht\//base: \//g" /var/www/html/.Build/$VERSION/config/sites/main/config.yaml
-  sed -i -e 's/base: \/en\//base: \//g' /var/www/html/.Build/$VERSION/config/sites/main/config.yaml
-}
-
-# Function to perform post-setup tasks for TYPO3 version 12.
-# It sets up TYPO3 by running the installation setup, configuring TYPO3 settings,
-# and modifying configuration files to enable deprecations and adjust base paths.
-function post_setup_12 {
-  $TYPO3_BIN install:setup -n --database-name $DATABASE
-  setup_typo3
-
-  sed -i "/'deprecations'/,/^[[:space:]]*'disabled' => true,/s/'disabled' => true,/'disabled' => false,/" /var/www/html/.Build/$VERSION/config/system/settings.php
-
-  sed -i -e "s/base: ht\//base: \//g" /var/www/html/.Build/$VERSION/config/sites/main/config.yaml
-  sed -i -e 's/base: \/en\//base: \//g' /var/www/html/.Build/$VERSION/config/sites/main/config.yaml
 }
 
 # Function to perform post-setup tasks for TYPO3 version 13.

--- a/.ddev/config.typo3-setup.yaml
+++ b/.ddev/config.typo3-setup.yaml
@@ -1,0 +1,8 @@
+type: php
+docroot: .Build
+additional_hostnames:
+  - 13.xima-typo3-content-planner
+  - 14.xima-typo3-content-planner
+hooks:
+   post-start:
+    - exec: mkdir -p /var/www/html/.Build/ && cp /var/www/html/.ddev/.setup/templates/* /var/www/html/.Build/

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -4,9 +4,6 @@ docroot: .Build
 php_version: "8.2"
 webserver_type: apache-fpm
 xdebug_enabled: false
-additional_hostnames:
-    - 13.xima-typo3-content-planner
-    - 14.xima-typo3-content-planner
 additional_fqdns: []
 database:
     type: mariadb
@@ -14,7 +11,6 @@ database:
 hooks:
     post-start:
         - exec: composer install --ignore-platform-reqs --no-scripts
-        - exec: mkdir -p /var/www/html/.Build/ && cp /var/www/html/.ddev/.setup/templates/* /var/www/html/.Build/
 webimage_extra_packages: [libxml2-utils]
 use_dns_when_possible: true
 composer_version: "2"

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -7,7 +7,7 @@ xdebug_enabled: false
 additional_fqdns: []
 database:
     type: mariadb
-    version: "10.4"
+    version: "10.6"
 hooks:
     post-start:
         - exec: composer install --ignore-platform-reqs --no-scripts


### PR DESCRIPTION
## Summary

- Split typo3-setup specific DDEV config into a dedicated `config.typo3-setup.yaml` file (hostnames + template copy hook)
- Bump MariaDB from 10.4 to 10.6
- Drop TYPO3 v11/v12 setup support (no longer maintained), remove obsolete `typo3cms` binary branch and per-version post-setup functions
- Add `setup_site_config` step that templates site configuration from `.ddev/.setup/templates/config` with `__VERSION__` / `__EXTENSION_NAME__` placeholders
- Add `bk2k/bootstrap-package` to the test fixture install

## Changes

- `.ddev/config.typo3-setup.yaml` (new) — separate DDEV config for typo3-setup (hostnames + template copy)
- `.ddev/config.yaml` — remove hostnames + template copy hook, bump MariaDB 10.4 → 10.6
- `.ddev/.setup/scripts/utils.sh` — drop v11/v12 branches, add `setup_site_config` templating, install bootstrap-package