### PR TITLE
fix(ci): keep PHPStan green when composer.lock pins TYPO3 v13

### DIFF
--- a/Classes/EventListener/ModifyRecordListRecordActionsListener.php
+++ b/Classes/EventListener/ModifyRecordListRecordActionsListener.php
@@ -15,7 +15,6 @@ namespace Xima\XimaTypo3ContentPlanner\EventListener;
 
 use Doctrine\DBAL\Exception;
 use TYPO3\CMS\Backend\RecordList\Event\ModifyRecordListRecordActionsEvent;
-use TYPO3\CMS\Backend\Template\Components\ActionGroup;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
 use TYPO3\CMS\Core\Domain\RecordInterface;
 use TYPO3\CMS\Core\Imaging\{IconFactory, IconSize};
@@ -28,6 +27,7 @@ use Xima\XimaTypo3ContentPlanner\Utility\Compatibility\{ComponentFactoryUtility,
 use Xima\XimaTypo3ContentPlanner\Utility\ExtensionUtility;
 use Xima\XimaTypo3ContentPlanner\Utility\Security\PermissionUtility;
 
+use function constant;
 use function count;
 use function is_array;
 
@@ -60,7 +60,7 @@ final readonly class ModifyRecordListRecordActionsListener
             return;
         }
         // TYPO3 v13/v14 compatibility: In v14 getRecord() returns RecordInterface, in v13 it returns array
-        // @phpstan-ignore instanceof.alwaysTrue, method.notFound
+        // @phpstan-ignore instanceof.alwaysTrue, instanceof.alwaysFalse, method.notFound
         $table = $event->getRecord() instanceof RecordInterface ? $event->getRecord()->getMainType() : $event->getTable();
 
         if (!ExtensionUtility::isRegisteredRecordTable($table) || $event->hasAction('Status')) {
@@ -73,7 +73,7 @@ final readonly class ModifyRecordListRecordActionsListener
         }
 
         // TYPO3 v13/v14 compatibility: In v14 getRecord() returns RecordInterface, in v13 it returns array
-        // @phpstan-ignore instanceof.alwaysTrue
+        // @phpstan-ignore instanceof.alwaysTrue, instanceof.alwaysFalse, method.notFound, offsetAccess.nonOffsetAccessible
         $uid = $event->getRecord() instanceof RecordInterface ? $event->getRecord()->getUid() : $event->getRecord()['uid'];
 
         // ToDo: this is necessary cause the status is not in the record, pls check tca for this
@@ -101,10 +101,16 @@ final readonly class ModifyRecordListRecordActionsListener
             $dropDownButton->addItem($actionToAdd);
         }
 
+        // ActionGroup::primary is v14-only; resolve via constant() at runtime
+        // so PHPStan does not need to know the v14 enum when analysing v13.
+        $primaryGroup = VersionUtility::is14OrHigher()
+            ? constant('TYPO3\\CMS\\Backend\\Template\\Components\\ActionGroup::primary')
+            : 'primary';
+
         $event->setAction(
             VersionUtility::is14OrHigher() ? $dropDownButton : $dropDownButton->render(),
             'Status',
-            VersionUtility::is14OrHigher() ? ActionGroup::primary : 'primary',
+            $primaryGroup,
             'delete',
         );
     }

--- a/Classes/Utility/Compatibility/ComponentFactoryUtility.php
+++ b/Classes/Utility/Compatibility/ComponentFactoryUtility.php
@@ -28,6 +28,7 @@ class ComponentFactoryUtility
     public static function createDropDownButton(): DropDownButton
     {
         if (VersionUtility::is14OrHigher()) {
+            // @phpstan-ignore method.notFound
             return self::getComponentFactory()->createDropDownButton();
         }
 
@@ -37,6 +38,7 @@ class ComponentFactoryUtility
     public static function createDropDownItem(): DropDownItem
     {
         if (VersionUtility::is14OrHigher()) {
+            // @phpstan-ignore method.notFound
             return self::getComponentFactory()->createDropDownItem();
         }
 
@@ -46,6 +48,7 @@ class ComponentFactoryUtility
     public static function createDropDownDivider(): DropDownDivider
     {
         if (VersionUtility::is14OrHigher()) {
+            // @phpstan-ignore method.notFound
             return self::getComponentFactory()->createDropDownDivider();
         }
 
@@ -55,6 +58,7 @@ class ComponentFactoryUtility
     public static function createDropDownHeader(): DropDownHeader
     {
         if (VersionUtility::is14OrHigher()) {
+            // @phpstan-ignore method.notFound
             return self::getComponentFactory()->createDropDownHeader();
         }
 
@@ -62,13 +66,16 @@ class ComponentFactoryUtility
     }
 
     /**
-     * @return \TYPO3\CMS\Backend\Template\Components\ComponentFactory
+     * Returns the v14-only ComponentFactory instance. Return type is `object`
+     * (not the FQN) so PHPStan does not have to resolve the v14 class when
+     * analysing against TYPO3 v13.
      */
     private static function getComponentFactory(): object
     {
-        // Use dynamic class name to avoid autoload issues on TYPO3 13
+        // Dynamic class name to avoid autoload issues on TYPO3 13
         $componentFactoryClass = 'TYPO3\\CMS\\Backend\\Template\\Components\\ComponentFactory';
 
+        // @phpstan-ignore argument.type
         return GeneralUtility::makeInstance($componentFactoryClass);
     }
 }

--- a/Classes/Utility/Rendering/AssetUtility.php
+++ b/Classes/Utility/Rendering/AssetUtility.php
@@ -15,8 +15,6 @@ namespace Xima\XimaTypo3ContentPlanner\Utility\Rendering;
 
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Resource\Exception\InvalidFileException;
-use TYPO3\CMS\Core\SystemResource\Publishing\{SystemResourcePublisherInterface, UriGenerationOptions};
-use TYPO3\CMS\Core\SystemResource\SystemResourceFactory;
 use TYPO3\CMS\Core\Utility\{GeneralUtility, PathUtility};
 use Xima\XimaTypo3ContentPlanner\Utility\Compatibility\VersionUtility;
 
@@ -75,18 +73,27 @@ class AssetUtility
     public static function getPublicResourcePath(string $resourcePath): string
     {
         if (VersionUtility::is14OrHigher()) {
-            /** @var SystemResourceFactory $resourceFactory */
-            $resourceFactory = GeneralUtility::makeInstance(SystemResourceFactory::class);
-            /** @var SystemResourcePublisherInterface $resourcePublisher */
-            $resourcePublisher = GeneralUtility::makeInstance(SystemResourcePublisherInterface::class);
+            // FQN strings to keep PHPStan happy when analysing against TYPO3 v13,
+            // where these classes do not exist. Runtime path is v14-only anyway.
+            $factoryClass = 'TYPO3\\CMS\\Core\\SystemResource\\SystemResourceFactory';
+            $publisherClass = 'TYPO3\\CMS\\Core\\SystemResource\\Publishing\\SystemResourcePublisherInterface';
+            $optionsClass = 'TYPO3\\CMS\\Core\\SystemResource\\Publishing\\UriGenerationOptions';
+
+            // @phpstan-ignore argument.type
+            $resourceFactory = GeneralUtility::makeInstance($factoryClass);
+            // @phpstan-ignore argument.type
+            $resourcePublisher = GeneralUtility::makeInstance($publisherClass);
+            // @phpstan-ignore class.notFound, method.notFound
             $resource = $resourceFactory->createPublicResource($resourcePath);
             /** @var ServerRequestInterface|null $request */
             $request = $GLOBALS['TYPO3_REQUEST'] ?? null;
 
+            // @phpstan-ignore class.notFound, method.notFound
             return (string) $resourcePublisher->generateUri(
                 $resource,
                 $request,
-                new UriGenerationOptions(absoluteUri: false),
+                // @phpstan-ignore class.notFound
+                new $optionsClass(absoluteUri: false),
             );
         }
 

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -31,6 +31,9 @@ return static function (ContainerConfigurator $configurator, ContainerBuilder $c
      */
     if ($typo3Version->getMajorVersion() >= 14 && $containerBuilder->hasDefinition(WidgetRegistry::class)) {
         $services->set('dashboard.widget.contentPlanner-configurable')
+            // Widget class is excluded from PHPStan analysis (see phpstan.neon)
+            // because it implements v14-only interfaces.
+            // @phpstan-ignore class.notFound
             ->class(Xima\XimaTypo3ContentPlanner\Widgets\ConfigurableContentStatusWidget::class)
             ->arg('$configuration', new Reference(WidgetConfigurationInterface::class))
             ->arg('$statusRepository', new Reference(StatusRepository::class))

--- a/Tests/CGL/phpstan.neon
+++ b/Tests/CGL/phpstan.neon
@@ -5,6 +5,11 @@ includes:
 parameters:
 	level: 6
 
+	# Allow unmatched ignores: necessary because the lock-file determines which
+	# TYPO3 major is installed when PHPStan runs, and some ignores only match
+	# in v13 or v14 (e.g. deprecation notices, instanceof always-true/always-false).
+	reportUnmatchedIgnoredErrors: false
+
 	scanDirectories:
 		- ../../vendor
 		- ../../vendor/phpunit/phpunit/src
@@ -17,6 +22,7 @@ parameters:
 		- ../../.Build (?)
 		# TYPO3 v14 only - uses classes that don't exist in v13
 		- ../../Classes/EventListener/AfterFileStorageTreeItemsPreparedListener.php
+		- ../../Classes/Widgets/ConfigurableContentStatusWidget.php
 
 	type_coverage:
 		constant: 0 # TODO: Set to 100, when PHP 8.3 is minimum requirement


### PR DESCRIPTION
## Summary

- Renovate's `lockFileMaintenance` consistently locks `typo3/cms-core` at v13.x even when `composer.json` allows `^13.4 || ^14.3` (same behaviour observed in [eliashaeussler/typo3-warming](https://github.com/eliashaeussler/typo3-warming)). The CGL job installs from that lock and runs PHPStan, which hit ~25 errors on v14-only API references.
- Lock-file is left as Renovate writes it; PHPStan is now happy against both TYPO3 v13 and v14, so Renovate can keep doing its thing.

## Strategy

Same model as typo3-warming: lock can stay on v13, source code must remain statically analysable against v13. The test matrix (`--with=typo3/cms-core:^X`) keeps verifying real behaviour on both majors.

## Changes

- `Tests/CGL/phpstan.neon` — `reportUnmatchedIgnoredErrors: false` (necessary because v13/v14 ignore identifiers diverge) and `ConfigurableContentStatusWidget.php` added to `excludePaths` (widget implements v14-only `WidgetRendererInterface`, already runtime-gated in `Configuration/Services.php`).
- `Classes/Utility/Rendering/AssetUtility.php` — `SystemResourceFactory`, `SystemResourcePublisherInterface`, `UriGenerationOptions` resolved via FQN strings + `@phpstan-ignore` so v13 analysis no longer trips on the v14-only namespace.
- `Classes/Utility/Compatibility/ComponentFactoryUtility.php` — return type of internal helper relaxed to `object`, `@phpstan-ignore method.notFound` on the four `createDropDown*()` proxy calls.
- `Classes/EventListener/ModifyRecordListRecordActionsListener.php` — `ActionGroup::primary` resolved via `constant('FQN::primary')`; `instanceof RecordInterface` ignores extended with v13-side identifiers (`instanceof.alwaysFalse`, `offsetAccess.nonOffsetAccessible`).
- `Configuration/Services.php` — `@phpstan-ignore class.notFound` for the widget class reference (widget is excluded from analysis).

## Verification

- `ddev cgl sca:php` against TYPO3 v13.4.26 → OK
- `ddev cgl sca:php` against TYPO3 v14.3.2 → OK
- `ddev cgl lint:php` → OK