### PR TITLE
feat: add extension title

### DIFF
--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -3,6 +3,10 @@
 	<file source-language="en" datatype="plaintext" original="messages">
 		<header/>
 		<body>
+			<trans-unit id="extension.title" resname="extension.title">
+				<source>Content Planner</source>
+				<target>Content Planner</target>
+			</trans-unit>
 			<trans-unit id="pages.tx_ximatypo3contentplanner_status">
 				<source>Status</source>
 				<target>Status</target>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -3,6 +3,9 @@
 	<file source-language="en" datatype="plaintext" original="messages">
 		<header/>
 		<body>
+			<trans-unit id="extension.title" resname="extension.title">
+				<source>Content Planner</source>
+			</trans-unit>
 			<trans-unit id="pages.tx_ximatypo3contentplanner_status">
 				<source>Status</source>
 			</trans-unit>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "xima/xima-typo3-content-planner",
-	"description": "This extension provides a page status functionality to support the planning of content work.",
+	"description": "Content Planner - This extension provides a page status functionality to support the planning of content work.",
 	"license": [
 		"GPL-2.0-or-later"
 	],


### PR DESCRIPTION
## Summary

- Add an `extension.title` label so the extension name ("Content Planner") is shown in the TYPO3 new record wizard
- Prepend the extension title to the composer.json description for display in the extension manager

## Changes

- `Resources/Private/Language/locallang_db.xlf` - Add `extension.title` trans-unit
- `Resources/Private/Language/de.locallang_db.xlf` - Add German `extension.title` translation
- `composer.json` - Prepend "Content Planner" to the description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated extension naming to "Content Planner" in English and German language files.
  * Updated product description metadata to reflect "Content Planner" branding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->