### PR TITLE
fix: normalize tags array in clearCachePostProc

### DIFF
--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -151,7 +151,7 @@ final readonly class DataHandlerHook // @phpstan-ignore-line complexity.classLik
     public function clearCachePostProc(array $params): void
     {
         $rawTags = $params['tags'] ?? [];
-        $tags = array_is_list($rawTags) ? array_values($rawTags) : array_keys($rawTags);
+        $tags = array_is_list($rawTags) ? $rawTags : array_keys($rawTags);
         if (in_array('uid_page', $params, true) && in_array('table', $params, true)) {
             $tags[] = $params['table'].'__pageId__'.$params['uid_page'];
         }

--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -150,7 +150,8 @@ final readonly class DataHandlerHook // @phpstan-ignore-line complexity.classLik
      */
     public function clearCachePostProc(array $params): void
     {
-        $tags = array_keys($params['tags']);
+        $rawTags = $params['tags'] ?? [];
+        $tags = array_is_list($rawTags) ? array_values($rawTags) : array_keys($rawTags);
         if (in_array('uid_page', $params, true) && in_array('table', $params, true)) {
             $tags[] = $params['table'].'__pageId__'.$params['uid_page'];
         }


### PR DESCRIPTION
## Summary

- Fix a `TypeError` triggered when an editor flushes the page cache in the TYPO3 backend
- TYPO3 core passes `$params['tags']` in two different formats depending on the code path: an associative map (`['pageId_5' => true]`) from the data-operation path, or a plain list (`['pageId_5']`) from the explicit `clear_cacheCmd()` page-flush path
- The previous code used `array_keys()` unconditionally, which returned integer indices for the list format and caused `AbstractFrontend::flushByTags()` to receive integers instead of strings

## Changes

- `Classes/Hooks/DataHandlerHook.php` - Use `array_is_list()` to detect the tags format and extract tag strings correctly from both associative and list variants