### PR TITLE
fix: suppress aborted notification message request in Firefox

### DIFF
--- a/Resources/Public/JavaScript/notification.js
+++ b/Resources/Public/JavaScript/notification.js
@@ -40,8 +40,9 @@ class Notification {
           top.TYPO3.Notification.error('Error', 'Failed to fetch notification message.');
         }
       }).catch(error => {
-          console.error('AJAX request failed:', error);
-          top.TYPO3.Notification.error('Error', 'Network error occurred while fetching notification message.');
+          // The request was likely aborted by a content frame refresh (e.g. Firefox NS_BINDING_ABORTED).
+          // The underlying action already completed, so the missing notification toast is non-critical.
+          console.debug('Content Planner: notification message request did not complete:', error);
       });
   }
 }


### PR DESCRIPTION
## Summary

- Fixes a spurious "Network error occurred while fetching notification message" error shown to editors in Firefox when saving a comment (or changing status / assignee).
- Root cause: the notification helper fetches a localized toast message via AJAX, but `Viewport.ContentContainer.refresh()` navigates the content frame before the request completes. Firefox aborts the in-flight request (`NS_BINDING_ABORTED`), which surfaced as a user-facing network error — even though the underlying action had already succeeded.
- The aborted request is now logged via `console.debug` instead of raising an alarming error notification. The fix is central in `notification.js`, so it covers all callers (comment, status, assignee, delete/resolve) across browsers and roles.
- Genuine server errors (HTTP 4xx/5xx) are unaffected and still surfaced via the existing `else` branch.

## Changes

- `Resources/Public/JavaScript/notification.js` - Replace the user-facing error toast in the `.catch()` branch with a `console.debug` log for aborted/failed notification fetches.

Closes #237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of interrupted requests so you’re less likely to see misleading network error notifications during page or content refreshes.
  * Reduced unnecessary error logging for requests that stop before completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->