### PR TITLE
fix: close orphaned comment document in opendocs toolbar (#238)

### DIFF
--- a/Classes/Controller/ProxyController.php
+++ b/Classes/Controller/ProxyController.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Xima\XimaTypo3ContentPlanner\Controller;
 
 use Psr\Http\Message\{ResponseInterface, ServerRequestInterface};
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\{JsonResponse, RedirectResponse};
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Messaging\{FlashMessage, FlashMessageQueue, FlashMessageService};
@@ -21,6 +22,9 @@ use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use Xima\XimaTypo3ContentPlanner\Configuration;
+
+use function count;
+use function is_array;
 
 /**
  * ProxyController.
@@ -178,6 +182,38 @@ class ProxyController extends ActionController
             'message' => $this->getLanguageService()->sL($message['message']),
             'severity' => $message['severity'],
         ]);
+    }
+
+    /**
+     * Removes orphaned "open document" references of the comment table from the FormEngine
+     * module data. Comments are edited through an ephemeral iframe modal: after saving, FormEngine
+     * re-renders the record in edit mode and registers it as an open document, which the modal then
+     * silently closes — leaving a stale entry in the "opendocs" toolbar. This cleans it up.
+     */
+    public function closeDocumentAction(ServerRequestInterface $request): ResponseInterface
+    {
+        /** @var BackendUserAuthentication $backendUser */
+        $backendUser = $GLOBALS['BE_USER'];
+        $docData = $backendUser->getModuleData('FormEngine');
+
+        if (!is_array($docData) || !isset($docData[0]) || !is_array($docData[0])) {
+            return new JsonResponse(['openDocuments' => 0, 'removed' => 0]);
+        }
+
+        $docHandler = $docData[0];
+        $removed = 0;
+        foreach ($docHandler as $identifier => $document) {
+            if (Configuration::TABLE_COMMENT === ($document[3]['table'] ?? null)) {
+                unset($docHandler[$identifier]);
+                ++$removed;
+            }
+        }
+
+        if ($removed > 0) {
+            $backendUser->pushModuleData('FormEngine', [$docHandler, $docData[1] ?? '']);
+        }
+
+        return new JsonResponse(['openDocuments' => count($docHandler), 'removed' => $removed]);
     }
 
     /**

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -32,4 +32,8 @@ return [
         'path' => '/content-planner/user-setting',
         'target' => Xima\XimaTypo3ContentPlanner\Controller\RecordController::class.'::userSettingAction',
     ],
+    'ximatypo3contentplanner_closedocument' => [
+        'path' => '/content-planner/close-document',
+        'target' => Xima\XimaTypo3ContentPlanner\Controller\ProxyController::class.'::closeDocumentAction',
+    ],
 ];

--- a/Resources/Public/JavaScript/create-and-edit-comment-modal.js
+++ b/Resources/Public/JavaScript/create-and-edit-comment-modal.js
@@ -3,6 +3,7 @@
 */
 import Modal from "@typo3/backend/modal.js"
 import Viewport from "@typo3/backend/viewport.js"
+import AjaxRequest from "@typo3/core/ajax/ajax-request.js"
 import Notification from "@xima/ximatypo3contentplanner/notification.js";
 
 class CreateAndEditCommentModal {
@@ -47,21 +48,39 @@ class CreateAndEditCommentModal {
           const isNew = iframe.contentWindow.document.querySelector('.is-new') !== null
           iframe.removeEventListener('load', initialLoad)
           iframe.addEventListener('load', function afterSubmit() {
-            Viewport.ContentContainer.refresh()
-            modal.hideModal()
+            const finish = () => {
+              Viewport.ContentContainer.refresh()
+              modal.hideModal()
 
-            Notification.message(isNew ? 'comment.create' : 'comment.edit', 'success')
-            if (element) {
-              element.dispatchEvent(new CustomEvent('typo3:contentplanner:reloadcomments', {
-                detail: {
-                  url: TYPO3.settings.ajaxUrls.ximatypo3contentplanner_comments,
-                  table,
-                  id: uid
-                },
-                bubbles: true,
-                composed: true
-              }))
+              Notification.message(isNew ? 'comment.create' : 'comment.edit', 'success')
+              if (element) {
+                element.dispatchEvent(new CustomEvent('typo3:contentplanner:reloadcomments', {
+                  detail: {
+                    url: TYPO3.settings.ajaxUrls.ximatypo3contentplanner_comments,
+                    table,
+                    id: uid
+                  },
+                  bubbles: true,
+                  composed: true
+                }))
+              }
             }
+
+            // Saving re-renders the comment in edit mode, registering it as an "open document".
+            // Clean up that orphaned reference before tearing down the modal (see issue #238).
+            new AjaxRequest(TYPO3.settings.ajaxUrls.ximatypo3contentplanner_closedocument)
+              .get()
+              .then(() => {
+                // Official opendocs refresh signal — the toolbar (top frame) re-renders on this event.
+                // No-op when opendocs is not installed (no listener registered).
+                try {
+                  top.document.dispatchEvent(new CustomEvent('typo3:opendocs:updateRequested'))
+                } catch (e) {
+                  // top frame not reachable — server-side state is already clean
+                }
+              })
+              .catch(error => console.debug('Content Planner: close-document request did not complete:', error))
+              .finally(finish)
           })
         })
       },

--- a/Tests/Unit/Controller/ProxyControllerTest.php
+++ b/Tests/Unit/Controller/ProxyControllerTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Tests\Unit\Controller;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Messaging\FlashMessageService;
+use Xima\XimaTypo3ContentPlanner\Configuration;
+use Xima\XimaTypo3ContentPlanner\Controller\ProxyController;
+
+/**
+ * ProxyControllerTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class ProxyControllerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER']);
+    }
+
+    public function testCloseDocumentActionRemovesCommentEntriesAndKeepsForeignTables(): void
+    {
+        $backendUser = $this->createMockBackendUser([
+            'FormEngine' => [
+                [
+                    'md5comment' => ['Title', [], 'storeUrl', ['table' => Configuration::TABLE_COMMENT, 'uid' => 42], 'returnUrl'],
+                    'md5page' => ['Page', [], 'storeUrl', ['table' => 'pages', 'uid' => 7], 'returnUrl'],
+                ],
+                'md5comment',
+            ],
+        ]);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $response = $this->createController()->closeDocumentAction($this->createRequest());
+
+        $payload = json_decode((string) $response->getBody(), true);
+        self::assertSame(1, $payload['removed']);
+        self::assertSame(1, $payload['openDocuments']);
+
+        // The comment entry was removed, the foreign (pages) entry persisted
+        self::assertNotNull($backendUser->pushed);
+        self::assertSame('FormEngine', $backendUser->pushed[0]);
+        self::assertArrayNotHasKey('md5comment', $backendUser->pushed[1][0]);
+        self::assertArrayHasKey('md5page', $backendUser->pushed[1][0]);
+    }
+
+    public function testCloseDocumentActionDoesNotPersistWhenNoCommentEntries(): void
+    {
+        $backendUser = $this->createMockBackendUser([
+            'FormEngine' => [
+                ['md5page' => ['Page', [], 'storeUrl', ['table' => 'pages', 'uid' => 7], 'returnUrl']],
+                'md5page',
+            ],
+        ]);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $response = $this->createController()->closeDocumentAction($this->createRequest());
+
+        $payload = json_decode((string) $response->getBody(), true);
+        self::assertSame(0, $payload['removed']);
+        self::assertSame(1, $payload['openDocuments']);
+        self::assertNull($backendUser->pushed);
+    }
+
+    public function testCloseDocumentActionHandlesEmptyModuleData(): void
+    {
+        $backendUser = $this->createMockBackendUser([]);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $response = $this->createController()->closeDocumentAction($this->createRequest());
+
+        $payload = json_decode((string) $response->getBody(), true);
+        self::assertSame(0, $payload['removed']);
+        self::assertSame(0, $payload['openDocuments']);
+        self::assertNull($backendUser->pushed);
+    }
+
+    private function createController(): ProxyController
+    {
+        return new ProxyController($this->createMock(FlashMessageService::class));
+    }
+
+    private function createRequest(): ServerRequestInterface
+    {
+        return $this->createMock(ServerRequestInterface::class);
+    }
+
+    /**
+     * @param array<string, mixed> $moduleData
+     */
+    private function createMockBackendUser(array $moduleData): object
+    {
+        return new class($moduleData) {
+            /** @var array<string, mixed> */
+            public array $stored;
+
+            /** @var array{0: string, 1: mixed}|null */
+            public ?array $pushed = null;
+
+            /**
+             * @param array<string, mixed> $moduleData
+             */
+            public function __construct(array $moduleData)
+            {
+                $this->stored = $moduleData;
+            }
+
+            public function getModuleData(string $key): mixed
+            {
+                return $this->stored[$key] ?? null;
+            }
+
+            public function pushModuleData(string $key, mixed $data): void
+            {
+                $this->pushed = [$key, $data];
+                $this->stored[$key] = $data;
+            }
+        };
+    }
+}

--- a/Tests/Unit/Controller/ProxyControllerTest.php
+++ b/Tests/Unit/Controller/ProxyControllerTest.php
@@ -105,18 +105,14 @@ final class ProxyControllerTest extends TestCase
     private function createMockBackendUser(array $moduleData): object
     {
         return new class($moduleData) {
-            /** @var array<string, mixed> */
-            public array $stored;
-
             /** @var array{0: string, 1: mixed}|null */
             public ?array $pushed = null;
 
             /**
-             * @param array<string, mixed> $moduleData
+             * @param array<string, mixed> $stored
              */
-            public function __construct(array $moduleData)
+            public function __construct(public array $stored)
             {
-                $this->stored = $moduleData;
             }
 
             public function getModuleData(string $key): mixed

--- a/Tests/Unit/Controller/ProxyControllerTest.php
+++ b/Tests/Unit/Controller/ProxyControllerTest.php
@@ -111,9 +111,7 @@ final class ProxyControllerTest extends TestCase
             /**
              * @param array<string, mixed> $stored
              */
-            public function __construct(public array $stored)
-            {
-            }
+            public function __construct(public array $stored) {}
 
             public function getModuleData(string $key): mixed
             {


### PR DESCRIPTION
## Summary

- Fix comments lingering as "open documents" in the core opendocs toolbar after saving via the comment modal (closes #238)
- Saving a comment re-renders it in FormEngine edit mode, which registers it as an open document; the modal then closes silently, leaving an orphaned toolbar entry
- Clean up that reference server-side and refresh the toolbar — works whether or not the optional `opendocs` system extension is installed

## Changes

- `Classes/Controller/ProxyController.php` — new `closeDocumentAction`: removes comment-table entries from the `FormEngine` open-documents module data and returns the new count
- `Configuration/Backend/AjaxRoutes.php` — register `ximatypo3contentplanner_closedocument` route
- `Resources/Public/JavaScript/create-and-edit-comment-modal.js` — call the cleanup endpoint after save and dispatch the official `typo3:opendocs:updateRequested` event to refresh the toolbar; tear down the modal only after the request settles (avoids the Firefox abort from #237)
- `Tests/Unit/Controller/ProxyControllerTest.php` — unit tests for the cleanup logic (removes comment entries, keeps foreign tables, no-op on empty data)

## Test plan

- [x] `ddev composer test` — 93 unit tests green (3 new)
- [x] PHPStan level 6 clean, `cgl lint`/`fix` clean
- [x] Manually verified in TYPO3 v13 and v14: comments no longer appear as open documents after saving