### PR TITLE
fix: refresh page tree after status change via edit form (#240)

### DIFF
--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -16,6 +16,7 @@ namespace Xima\XimaTypo3ContentPlanner\Hooks;
 use Doctrine\DBAL\Exception;
 use DOMDocument;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
@@ -143,6 +144,21 @@ final readonly class DataHandlerHook // @phpstan-ignore-line complexity.classLik
             $this->dispatchCommentEvents($status, $id, $fieldArray, $dataHandler);
             $this->updateCommentCountRelation($status, $id, $fieldArray, $dataHandler);
         }
+
+        if ($this->shouldRefreshPageTree($table, $fieldArray)) {
+            BackendUtility::setUpdateSignal('updatePageTree');
+        }
+    }
+
+    /**
+     * The page tree node color is derived from the content planner status field, but the core does
+     * not treat this custom field as tree-relevant — so a FormEngine save would not refresh the tree.
+     *
+     * @param array<string, mixed> $fieldArray
+     */
+    public function shouldRefreshPageTree(string $table, array $fieldArray): bool
+    {
+        return 'pages' === $table && array_key_exists(Configuration::FIELD_STATUS, $fieldArray);
     }
 
     /**

--- a/Tests/Unit/Hooks/DataHandlerHookTest.php
+++ b/Tests/Unit/Hooks/DataHandlerHookTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Tests\Unit\Hooks;
+
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
+use Xima\XimaTypo3ContentPlanner\Configuration;
+use Xima\XimaTypo3ContentPlanner\Domain\Repository\{CommentRepository, RecordRepository};
+use Xima\XimaTypo3ContentPlanner\Hooks\DataHandlerHook;
+use Xima\XimaTypo3ContentPlanner\Manager\StatusChangeManager;
+
+/**
+ * DataHandlerHookTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class DataHandlerHookTest extends TestCase
+{
+    public function testRefreshesPageTreeWhenPageStatusIsChanged(): void
+    {
+        self::assertTrue(
+            $this->createHook()->shouldRefreshPageTree('pages', [Configuration::FIELD_STATUS => 2]),
+        );
+    }
+
+    public function testRefreshesPageTreeWhenPageStatusIsReset(): void
+    {
+        self::assertTrue(
+            $this->createHook()->shouldRefreshPageTree('pages', [Configuration::FIELD_STATUS => null]),
+        );
+    }
+
+    public function testDoesNotRefreshWhenStatusFieldIsAbsent(): void
+    {
+        self::assertFalse(
+            $this->createHook()->shouldRefreshPageTree('pages', ['title' => 'New title']),
+        );
+    }
+
+    public function testDoesNotRefreshForNonPageTable(): void
+    {
+        self::assertFalse(
+            $this->createHook()->shouldRefreshPageTree('tx_news_domain_model_news', [Configuration::FIELD_STATUS => 2]),
+        );
+    }
+
+    private function createHook(): DataHandlerHook
+    {
+        return new DataHandlerHook(
+            $this->createMock(FrontendInterface::class),
+            $this->createMock(StatusChangeManager::class),
+            $this->createMock(RecordRepository::class),
+            $this->createMock(CommentRepository::class),
+            $this->createMock(EventDispatcherInterface::class),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes #240: changing a page status via the edit form (the status/flag link in the Content Planner header bar below the page title) did not refresh the page tree, so the old status color remained visible.
- The page tree node color is derived from the custom `tx_ximatypo3contentplanner_status` field, which TYPO3 core does not treat as tree-relevant — so a FormEngine save never triggered a tree refresh. The AJAX quick-change paths only worked because they explicitly dispatch `typo3:pagetree:refresh` client-side.
- Since the AJAX quick-change also routes through `tce_db → DataHandler`, a single server-side fix in the DataHandler hook covers both paths without any new JavaScript or routes.

## Changes

- `Classes/Hooks/DataHandlerHook.php` — after database operations, call `BackendUtility::setUpdateSignal('updatePageTree')` when `shouldRefreshPageTree()` is true (table is `pages` and the status field was actually written; covers both set and reset).
- `Tests/Unit/Hooks/DataHandlerHookTest.php` — unit tests for the firing condition (status change/reset → refresh; other fields or non-page tables → no refresh).

## Test plan

- [x] `ddev composer test` — 97 tests pass
- [x] PHPStan level 6 — no errors
- [x] Manually verified in TYPO3 v13 and v14: page tree color updates after editing status via the edit form; no regression or disruptive double-refresh on the dropdown/context-menu paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page tree updates so changes to a page’s status are reflected immediately in the backend.
  * Ensures the page tree also refreshes when a status value is cleared.

* **Tests**
  * Added coverage for page tree refresh behavior when the status field changes, is reset, or is not present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->