### PR TITLE
fix: guard undefined showitem key in user settings registration

### DIFF
--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -147,7 +147,7 @@ class Configuration
             'table' => 'be_users',
         ];
 
-        $GLOBALS['TYPO3_USER_SETTINGS']['showitem'] .= ','.$showitemAddition;
+        $GLOBALS['TYPO3_USER_SETTINGS']['showitem'] = ($GLOBALS['TYPO3_USER_SETTINGS']['showitem'] ?? '').','.$showitemAddition;
     }
 
     public static function registerPermissions(): void


### PR DESCRIPTION
## Summary

- Fix a PHP warning (`Undefined array key \"showitem\"`) triggered on TYPO3 v13 when registering the backend user setting.

## Details

`Configuration::registerUserSettings()` is invoked from `Configuration/TCA/Overrides/be_users.php`, which runs during TCA assembly — earlier than the former `ext_tables.php` location. At that point `$GLOBALS['TYPO3_USER_SETTINGS']['showitem']` is not yet initialized, so appending with `.=` raised an "Undefined array key" warning on the TYPO3 v13 code path.

The append now uses a null-coalescing guard, mirroring the pattern already used in the v14 TCA branch of the same method. The change is inert on v14 (that path returns early via `addUserSetting`).

Verified on TYPO3 v13.4.31: `BulkUpdateCommandTest` runs with 0 warnings (previously 1).

## Changes

- \`Classes/Configuration.php\` - guard `TYPO3_USER_SETTINGS['showitem']` with `?? ''` before appending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user settings handling so settings display content is updated correctly even when no existing display string is present.
  * Prevented a case where new settings entries could be appended incorrectly, ensuring more reliable behavior in older fallback paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->