### PR TITLE
docs: improve documentation accuracy and developer API coverage

### DIFF
--- a/Documentation/DeveloperCorner/ExtensionUtility.rst
+++ b/Documentation/DeveloperCorner/ExtensionUtility.rst
@@ -1,0 +1,79 @@
+..  include:: /Includes.rst.txt
+
+..  _extension_utility:
+
+=======================
+Extension Utility
+=======================
+
+The :php:`ExtensionUtility` is the public API for TCA configuration and feature
+management. Use it to register additional record tables (see
+:ref:`additional-records`) and to query the current extension configuration
+from your own code.
+
+..  php:namespace:: Xima\XimaTypo3ContentPlanner\Utility
+
+..  php:class:: ExtensionUtility
+
+    Utility class for TCA configuration and feature management.
+
+    ..  php:method:: addContentPlannerTabToTCA($table)
+
+        Add the "Content Planner" tab (status, assignee and comments palette) to
+        the TCA of the given table. Call this in a
+        :file:`Configuration/TCA/Overrides/<table>.php` file.
+
+        :param string $table: Table name to extend.
+        :returntype: :php:`void`
+
+    ..  php:method:: getRecordTables()
+
+        Get all tables that are tracked by the content planner. Includes
+        :sql:`pages`, the optionally enabled :sql:`tt_content` and filelist
+        tables as well as all tables registered via
+        :php:`registerAdditionalRecordTables`.
+
+        :returntype: :php:`string[]`
+
+    ..  php:method:: isRegisteredRecordTable($table)
+
+        Check whether the given table is tracked by the content planner.
+
+        :param string $table: Table name to check.
+        :returntype: :php:`bool`
+
+    ..  php:method:: isFilelistSupportEnabled()
+
+        Check whether filelist support (files and folders) is enabled via the
+        :ref:`enableFilelistSupport <extconf-enableFilelistSupport>` extension
+        configuration.
+
+        :returntype: :php:`bool`
+
+    ..  php:method:: isContentElementSupportEnabled()
+
+        Check whether content element support (:sql:`tt_content`) is enabled via
+        the :ref:`enableContentElementSupport <extconf-enableContentElementSupport>`
+        extension configuration.
+
+        :returntype: :php:`bool`
+
+    ..  php:method:: isFeatureEnabled($feature)
+
+        Check whether a boolean extension configuration feature is enabled.
+
+        :param string $feature: Configuration key, e.g. ``commentTodos``.
+        :returntype: :php:`bool`
+
+    ..  php:method:: getExtensionSetting($feature)
+
+        Get the raw value of an extension configuration option as string.
+
+        :param string $feature: Configuration key, e.g. ``treeStatusInformation``.
+        :returntype: :php:`string`
+
+..  seealso::
+
+    View the sources on GitHub:
+
+    -   `ExtensionUtility <https://github.com/xima-media/xima-typo3-content-planner/blob/main/Classes/Utility/ExtensionUtility.php>`__

--- a/Documentation/DeveloperCorner/Index.rst
+++ b/Documentation/DeveloperCorner/Index.rst
@@ -16,4 +16,5 @@ into the status process.
 
     AdditionalRecords
     Events
+    ExtensionUtility
     PlannerUtility

--- a/Documentation/DeveloperCorner/PlannerUtility.rst
+++ b/Documentation/DeveloperCorner/PlannerUtility.rst
@@ -80,6 +80,13 @@ The :php:`PlannerUtility` can be used to easily interact programmatically with t
         :param string|null $like: Optional string to filter comments by content.
         :returntype: :php:`void`
 
+    ..  php:method:: hasComments($record)
+
+        Simple function to check whether a record has comments.
+
+        :param array $record: Record array containing the content planner comment counter field.
+        :returntype: :php:`bool`
+
 ..  seealso::
 
     View the sources on GitHub:

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -12,7 +12,7 @@ Requirements
 ============
 
 -   PHP 8.2 - 8.5
--   TYPO3 13.4 LTS & 14.0+
+-   TYPO3 13.4 LTS & 14.3+
 
 Version Matrix
 --------------

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This TYPO3 extension adds content planning capabilities to the TYPO3 backend: as
 
 ### Requirements
 
-* TYPO3 13.4 LTS & 14.0+
+* TYPO3 13.4 LTS & 14.3+
 * PHP 8.2+
 
 ### Supports


### PR DESCRIPTION
## Summary

- Correct the minimum supported TYPO3 v14 version in the documentation to match the actual Composer constraint (`^14.3`)
- Add a dedicated reference page for the public `ExtensionUtility` API (TCA configuration & feature management)
- Document the previously missing `PlannerUtility::hasComments()` method

## Changes

- `Documentation/Installation/Index.rst`, `README.md` — fix requirement statement from "14.0+" to "14.3+" (Composer requires `^13.4 || ^14.3`, so 14.0–14.2 are not supported)
- `Documentation/DeveloperCorner/ExtensionUtility.rst` — new reference page covering `addContentPlannerTabToTCA`, `getRecordTables`, `isRegisteredRecordTable`, `isFilelistSupportEnabled`, `isContentElementSupportEnabled`, `isFeatureEnabled`, `getExtensionSetting`
- `Documentation/DeveloperCorner/Index.rst` — add ExtensionUtility to the toctree
- `Documentation/DeveloperCorner/PlannerUtility.rst` — document `hasComments()`, completing the public API coverage

## Notes

`ext_emconf.php` keeps the broad range `13.4.0-14.3.99` — the TER single-range format cannot express "13.4–13.x **or** 14.3+"; Composer remains authoritative.