### PR TITLE
chore: remove unused translation keys

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -83,30 +83,6 @@
 				<source>Assignee</source>
 				<target>Zuständigkeit</target>
 			</trans-unit>
-			<trans-unit id="widgets.contentPlanner.header.author">
-				<source>Author</source>
-				<target>Autor</target>
-			</trans-unit>
-			<trans-unit id="widgets.contentPlanner.header.comment">
-				<source>Comment</source>
-				<target>Kommentar</target>
-			</trans-unit>
-			<trans-unit id="widgets.contentPlanner.header.comments">
-				<source>Comments</source>
-				<target>Kommentare</target>
-			</trans-unit>
-			<trans-unit id="widgets.contentPlanner.header.page">
-				<source>Page</source>
-				<target>Seite</target>
-			</trans-unit>
-			<trans-unit id="widgets.contentPlanner.header.user">
-				<source>User</source>
-				<target>Benutzer</target>
-			</trans-unit>
-			<trans-unit id="widgets.contentPlanner.header.change">
-				<source>Change note</source>
-				<target>Änderungshinweis</target>
-			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.status.assignee">
 				<source><![CDATA[There are currently <span class="badge">0</span> content planner records assigned to you.]]></source>
 				<target><![CDATA[Aktuell sind dir <span class="badge">0</span> Content Planner Datensätze zugewiesen.]]></target>
@@ -209,10 +185,6 @@
 			<trans-unit id="button.modal.footer.edit">
 				<source>Edit</source>
 				<target>Bearbeiten</target>
-			</trans-unit>
-			<trans-unit id="button.modal.footer.save">
-				<source>Save</source>
-				<target>Speichern</target>
 			</trans-unit>
 
 			<!-- header info -->
@@ -460,6 +432,12 @@
 			<trans-unit id="assignee.documentation">
 				<source><![CDATA[You can find more information about the assignee feature in the <a href="https://docs.typo3.org/p/xima/xima-typo3-content-planner/main/en-us/Usage/Assignee.html" target="_blank">official documentation</a> of the extension.]]></source>
 				<target><![CDATA[Weitere Informationen zur Zuständigen-Funktion findest du in der <a href="https://docs.typo3.org/p/xima/xima-typo3-content-planner/main/de-de/Usage/Assignee.html" target="_blank">offiziellen Dokumentation</a> der Extension.]]></target>
+			</trans-unit>
+
+			<!-- mail -->
+			<trans-unit id="mail.signature">
+				<source></source>
+				<target></target>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -7,22 +7,6 @@
 				<source>Content Status</source>
 				<target>Inhaltsstatus</target>
 			</trans-unit>
-			<trans-unit id="status.danger">
-				<source>Pending</source>
-				<target>Ausstehend</target>
-			</trans-unit>
-			<trans-unit id="status.info">
-				<source>In progress</source>
-				<target>In Bearbeitung</target>
-			</trans-unit>
-			<trans-unit id="status.warning">
-				<source>Needs review</source>
-				<target>Benötigt Überprüfung</target>
-			</trans-unit>
-			<trans-unit id="status.success">
-				<source>Completed</source>
-				<target>Abgeschlossen</target>
-			</trans-unit>
 			<trans-unit id="reset">
 				<source>Reset Status</source>
 				<target>Status zurücksetzen</target>
@@ -37,10 +21,6 @@
 			</trans-unit>
 			<trans-unit id="comments.todo">
 				<source>ToDo(s)</source>
-			</trans-unit>
-			<trans-unit id="currentAssignee">
-				<source>Current Assignee</source>
-				<target>Aktueller Zuständiger</target>
 			</trans-unit>
 			<trans-unit id="header.unassigned">
 				<source>-- Not assigned --</source>

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -3,10 +3,6 @@
 	<file source-language="en" datatype="plaintext" original="messages">
 		<header/>
 		<body>
-			<trans-unit id="extension.title" resname="extension.title">
-				<source>Content Planner</source>
-				<target>Content Planner</target>
-			</trans-unit>
 			<trans-unit id="pages.tx_ximatypo3contentplanner_status">
 				<source>Status</source>
 				<target>Status</target>
@@ -26,14 +22,6 @@
 			<trans-unit id="tx_ximatypo3contentplanner_comment.content">
 				<source>Content</source>
 				<target>Inhalt</target>
-			</trans-unit>
-			<trans-unit id="tx_ximatypo3contentplanner_comment.resolved">
-				<source>Resolved</source>
-				<target>Erledigt</target>
-			</trans-unit>
-			<trans-unit id="tx_ximatypo3contentplanner_comment.author">
-				<source>Author</source>
-				<target>Autor</target>
 			</trans-unit>
 			<trans-unit id="be_users.tx_ximatypo3contentplanner_hide">
 				<source>Hide content planner</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -63,24 +63,6 @@
 			<trans-unit id="widgets.contentPlanner.header.assignee">
 				<source>Assignee</source>
 			</trans-unit>
-			<trans-unit id="widgets.contentPlanner.header.author">
-				<source>Author</source>
-			</trans-unit>
-			<trans-unit id="widgets.contentPlanner.header.comment">
-				<source>Comment</source>
-			</trans-unit>
-			<trans-unit id="widgets.contentPlanner.header.comments">
-				<source>Comments</source>
-			</trans-unit>
-			<trans-unit id="widgets.contentPlanner.header.page">
-				<source>Page</source>
-			</trans-unit>
-			<trans-unit id="widgets.contentPlanner.header.user">
-				<source>User</source>
-			</trans-unit>
-			<trans-unit id="widgets.contentPlanner.header.change">
-				<source>Change note</source>
-			</trans-unit>
 			<trans-unit id="widgets.contentPlanner.status.assignee">
 				<source><![CDATA[There are currently <span class="badge">0</span> content planner records assigned to you.]]></source>
 			</trans-unit>
@@ -99,9 +81,6 @@
 			</trans-unit>
 			<trans-unit id="button.modal.footer.edit">
 				<source>Edit</source>
-			</trans-unit>
-			<trans-unit id="button.modal.footer.save">
-				<source>Save</source>
 			</trans-unit>
 			<!-- header info -->
 			<trans-unit id="header.status">
@@ -347,6 +326,11 @@
 			</trans-unit>
 			<trans-unit id="widgets.configurable.setting.recordType.all">
 				<source>All record types</source>
+			</trans-unit>
+
+			<!-- mail -->
+			<trans-unit id="mail.signature">
+				<source></source>
 			</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -6,18 +6,6 @@
 			<trans-unit id="status">
 				<source>Content Status</source>
 			</trans-unit>
-			<trans-unit id="status.danger">
-				<source>Pending</source>
-			</trans-unit>
-			<trans-unit id="status.info">
-				<source>In progress</source>
-			</trans-unit>
-			<trans-unit id="status.warning">
-				<source>Needs review</source>
-			</trans-unit>
-			<trans-unit id="status.success">
-				<source>Completed</source>
-			</trans-unit>
 			<trans-unit id="reset">
 				<source>Reset Status</source>
 			</trans-unit>
@@ -29,9 +17,6 @@
 			</trans-unit>
 			<trans-unit id="comments.todo">
 				<source>ToDo(s)</source>
-			</trans-unit>
-			<trans-unit id="currentAssignee">
-				<source>Current Assignee</source>
 			</trans-unit>
 			<trans-unit id="header.unassigned">
 				<source>-- Not assigned --</source>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -3,9 +3,6 @@
 	<file source-language="en" datatype="plaintext" original="messages">
 		<header/>
 		<body>
-			<trans-unit id="extension.title" resname="extension.title">
-				<source>Content Planner</source>
-			</trans-unit>
 			<trans-unit id="pages.tx_ximatypo3contentplanner_status">
 				<source>Status</source>
 			</trans-unit>
@@ -20,12 +17,6 @@
 			</trans-unit>
 			<trans-unit id="tx_ximatypo3contentplanner_comment.content">
 				<source>Content</source>
-			</trans-unit>
-			<trans-unit id="tx_ximatypo3contentplanner_comment.resolved">
-				<source>Resolved</source>
-			</trans-unit>
-			<trans-unit id="tx_ximatypo3contentplanner_comment.author">
-				<source>Author</source>
 			</trans-unit>
 			<trans-unit id="be_users.tx_ximatypo3contentplanner_hide">
 				<source>Hide content planner</source>


### PR DESCRIPTION
## Summary

- Remove 15 genuinely unused (orphan) translation keys flagged by the translation validator, keeping source and German translation files in sync
- Declare `mail.signature` as an optional, empty label so the existing `Email.html` reference resolves (runtime behavior unchanged — the template already uses `default: ''`)

The remaining keys reported by the validator were verified as false positives (referenced dynamically via JS `TYPO3.lang`, runtime string concatenation in `DiffUtility`, Fluid variable keys, or LLL refs in `Services.php`) and were intentionally left untouched.

## Changes

- `Resources/Private/Language/locallang.xlf` (+ `de.`) — remove `widgets.contentPlanner.header.{author,comment,comments,page,user,change}`, `button.modal.footer.save`; add empty `mail.signature`
- `Resources/Private/Language/locallang_be.xlf` (+ `de.`) — remove `status.{danger,info,warning,success}`, `currentAssignee`
- `Resources/Private/Language/locallang_db.xlf` (+ `de.`) — remove `extension.title`, `tx_ximatypo3contentplanner_comment.{resolved,author}`