### PR TITLE
fix: add missing assignee modal label and silence runtime-assembled keys

### DIFF
--- a/Configuration/TranslationValidator.yaml
+++ b/Configuration/TranslationValidator.yaml
@@ -1,0 +1,9 @@
+orphans:
+  # These key families are assembled at runtime and cannot be detected statically:
+  #   - timeAgo.*                    DiffUtility builds 'timeAgo.' . $unit
+  #   - history.*                    DiffUtility builds 'history.record|comment|reply.' . $parts
+  #   - comment.actions.{status}.*   Fluid resolves {status} (resolve|unresolve) at render time
+  suppressions:
+    - 'timeAgo.*'
+    - 'history.*'
+    - 'comment.actions.*'

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -174,6 +174,10 @@
 				<source>Comments</source>
 				<target>Kommentare</target>
 			</trans-unit>
+			<trans-unit id="button.modal.header.assignee">
+				<source>Assignee</source>
+				<target>Zuständigkeit</target>
+			</trans-unit>
 			<trans-unit id="button.modal.footer.close">
 				<source>Cancel</source>
 				<target>Abbrechen</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -73,6 +73,9 @@
 			<trans-unit id="button.modal.header.comments">
 				<source>Comments</source>
 			</trans-unit>
+			<trans-unit id="button.modal.header.assignee">
+				<source>Assignee</source>
+			</trans-unit>
 			<trans-unit id="button.modal.footer.close">
 				<source>Cancel</source>
 			</trans-unit>


### PR DESCRIPTION
## Summary

- **Fix a missing German label.** `assignee-selection-modal.js:44` references `TYPO3.lang['button.modal.header.assignee']`, but the key was never defined — only `button.modal.header.comments` existed. At runtime the JS fallback `|| 'Assignee'` rendered the English word even in German. Adds the trans-unit (EN `Assignee` / DE `Zuständigkeit`) to the source and German XLIFF.
- **Add a translation-validator config.** `Configuration/TranslationValidator.yaml` suppresses the three key families that are assembled at runtime and cannot be detected statically (`timeAgo.*`, `history.*`, `comment.actions.*`), so `translations:orphans` reports cleanly instead of 35 known false positives.

After both changes the validator reports `[OK] Clean` — no orphans, no missing references.

## Changes

- `Resources/Private/Language/locallang.xlf` / `de.locallang.xlf` — add `button.modal.header.assignee`
- `Configuration/TranslationValidator.yaml` — suppress runtime-assembled key families