### PR TITLE
docs: update security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,19 +1,6 @@
 # Security Policy
 
-If you believe you have found a vulnerability in this project, please follow the guidelines below.
-
 > [!CAUTION]
-> Please do not create GitHub issues for security vulnerabilities!
+> **Please avoid using GitHub issues to report security vulnerabilities.**
 
-## Reporting a Vulnerability
-
-Please contact [hej@konradmichalik.dev](mailto:hej@konradmichalik.dev) instead.
-Your report should include the following information:
-
-- The exact version or version range you analyzed.
-- The TYPO3 version used during your analysis.
-- A step-by-step description of how to exploit the potential vulnerability.
-
-> [!TIP]
-> If you suspect a critical vulnerability, you may also contact the _TYPO3 Security Team_. For further details, please
-> refer to  [TYPO3's Security Policy](https://github.com/TYPO3/typo3/blob/main/SECURITY.md).
+If you have found a potential security flaw, please reach out directly to the [TYPO3 Security Team](https://typo3.community/contribute/teams-committees/security). For additional information and guidelines, you can also check out [TYPO3's Security Policy](https://github.com/TYPO3/typo3/blob/main/SECURITY.md).


### PR DESCRIPTION
Updates `SECURITY.md` to direct vulnerability reports to the TYPO3 Security Team instead of GitHub issues.

Closes #249 