### PR TITLE
fix: require authentication and permissions for folder status endpoint

### DIFF
--- a/Classes/Controller/FolderController.php
+++ b/Classes/Controller/FolderController.php
@@ -16,10 +16,13 @@ namespace Xima\XimaTypo3ContentPlanner\Controller;
 use Doctrine\DBAL\Exception;
 use InvalidArgumentException;
 use Psr\Http\Message\{ResponseInterface, ServerRequestInterface};
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\{JsonResponse, RedirectResponse};
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use Xima\XimaTypo3ContentPlanner\Domain\Repository\FolderStatusRepository;
 use Xima\XimaTypo3ContentPlanner\Utility\ExtensionUtility;
+use Xima\XimaTypo3ContentPlanner\Utility\Security\PermissionUtility;
 
 use function is_array;
 
@@ -64,11 +67,16 @@ class FolderController extends ActionController
             $status = null;
         }
 
+        if (!$this->isChangeAllowed($status, $assignee)) {
+            return new JsonResponse(['error' => 'Insufficient permissions'], 403);
+        }
+
         try {
             $uid = $this->folderStatusRepository->createOrUpdate($identifier, $status, $assignee);
 
-            // If redirect URL is provided, redirect instead of returning JSON
-            if (null !== $redirect && '' !== $redirect) {
+            // If a valid local redirect URL is provided, redirect instead of returning JSON
+            $redirect = null !== $redirect ? GeneralUtility::sanitizeLocalUrl($redirect) : '';
+            if ('' !== $redirect) {
                 return new RedirectResponse($redirect);
             }
 
@@ -80,5 +88,34 @@ class FolderController extends ActionController
         } catch (InvalidArgumentException $e) {
             return new JsonResponse(['error' => $e->getMessage()], 400);
         }
+    }
+
+    /**
+     * Verify the current backend user is allowed to perform the requested status/assignee change.
+     */
+    private function isChangeAllowed(?int $status, ?int $assignee): bool
+    {
+        if (!PermissionUtility::checkContentStatusVisibility()) {
+            return false;
+        }
+
+        $statusAllowed = null === $status
+            ? PermissionUtility::canUnsetStatus()
+            : PermissionUtility::canChangeStatus($status);
+        if (!$statusAllowed) {
+            return false;
+        }
+
+        if (null !== $assignee && $assignee > 0) {
+            /** @var BackendUserAuthentication $backendUser */
+            $backendUser = $GLOBALS['BE_USER'];
+            $currentUserId = (int) ($backendUser->user['uid'] ?? 0);
+
+            return $assignee === $currentUserId
+                ? PermissionUtility::canAssignSelf()
+                : PermissionUtility::canAssignOthers();
+        }
+
+        return true;
     }
 }

--- a/Configuration/Backend/Routes.php
+++ b/Configuration/Backend/Routes.php
@@ -19,7 +19,6 @@ return [
     ],
     'ximatypo3contentplanner_folder_status_update' => [
         'path' => '/content-planner/folder/status/update',
-        'access' => 'public',
         'target' => Xima\XimaTypo3ContentPlanner\Controller\FolderController::class.'::updateStatusAction',
     ],
     'ximatypo3contentplanner_share' => [

--- a/Tests/Functional/Controller/FolderControllerTest.php
+++ b/Tests/Functional/Controller/FolderControllerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Tests\Functional\Controller;
+
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\RedirectResponse;
+use Xima\XimaTypo3ContentPlanner\Configuration;
+use Xima\XimaTypo3ContentPlanner\Controller\FolderController;
+use Xima\XimaTypo3ContentPlanner\Domain\Repository\FolderStatusRepository;
+use Xima\XimaTypo3ContentPlanner\Tests\Functional\AbstractFunctionalTestCase;
+
+/**
+ * FolderControllerTest.
+ *
+ * Redirect handling relies on GeneralUtility::sanitizeLocalUrl(), which needs an initialized
+ * Environment — only available in the functional bootstrap, hence these cases live here.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class FolderControllerTest extends AbstractFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY]['enableFilelistSupport'] = 1;
+        $this->loginBackendUser();
+    }
+
+    #[Test]
+    public function updateStatusActionIgnoresExternalRedirect(): void
+    {
+        $response = $this->createController()->updateStatusAction(
+            $this->createRequest(['identifier' => '1:/user_upload/', 'status' => '3', 'redirect' => 'https://evil.example/']),
+        );
+
+        self::assertNotInstanceOf(RedirectResponse::class, $response);
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    private function createController(): FolderController
+    {
+        return new FolderController($this->get(FolderStatusRepository::class));
+    }
+
+    /**
+     * @param array<string, mixed> $queryParams
+     */
+    private function createRequest(array $queryParams): ServerRequestInterface
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getParsedBody')->willReturn([]);
+        $request->method('getQueryParams')->willReturn($queryParams);
+
+        return $request;
+    }
+}

--- a/Tests/Unit/Controller/FolderControllerTest.php
+++ b/Tests/Unit/Controller/FolderControllerTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Tests\Unit\Controller;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Http\RedirectResponse;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Xima\XimaTypo3ContentPlanner\Configuration;
+use Xima\XimaTypo3ContentPlanner\Controller\FolderController;
+use Xima\XimaTypo3ContentPlanner\Domain\Repository\FolderStatusRepository;
+use Xima\XimaTypo3ContentPlanner\Utility\Security\PermissionUtility;
+
+/**
+ * FolderControllerTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class FolderControllerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER']);
+        PermissionUtility::resetCache();
+        GeneralUtility::purgeInstances();
+    }
+
+    public function testFolderStatusUpdateRouteIsNotPublic(): void
+    {
+        $routes = require __DIR__.'/../../../Configuration/Backend/Routes.php';
+
+        self::assertArrayHasKey('ximatypo3contentplanner_folder_status_update', $routes);
+        self::assertNotSame(
+            'public',
+            $routes['ximatypo3contentplanner_folder_status_update']['access'] ?? null,
+            'The folder status update route must not be publicly accessible (auth + CSRF token required).',
+        );
+    }
+
+    public function testUpdateStatusActionDeniesUserWithoutPermission(): void
+    {
+        $GLOBALS['BE_USER'] = $this->createBackendUser(isAdmin: false, permitted: false);
+        $this->enableFilelistSupport();
+
+        $repository = $this->createMock(FolderStatusRepository::class);
+        $repository->expects(self::never())->method('createOrUpdate');
+
+        $response = (new FolderController($repository))->updateStatusAction(
+            $this->createRequest(['identifier' => '1:/user_upload/', 'status' => '3']),
+        );
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    public function testUpdateStatusActionPersistsForPermittedUser(): void
+    {
+        $GLOBALS['BE_USER'] = $this->createBackendUser(isAdmin: true, permitted: true);
+        $this->enableFilelistSupport();
+
+        $repository = $this->createMock(FolderStatusRepository::class);
+        $repository->expects(self::once())
+            ->method('createOrUpdate')
+            ->with('1:/user_upload/', 3, null)
+            ->willReturn(42);
+
+        $response = (new FolderController($repository))->updateStatusAction(
+            $this->createRequest(['identifier' => '1:/user_upload/', 'status' => '3']),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = json_decode((string) $response->getBody(), true);
+        self::assertTrue($payload['success']);
+        self::assertSame(42, $payload['uid']);
+    }
+
+    public function testUpdateStatusActionIgnoresExternalRedirect(): void
+    {
+        $GLOBALS['BE_USER'] = $this->createBackendUser(isAdmin: true, permitted: true);
+        $this->enableFilelistSupport();
+
+        $repository = $this->createMock(FolderStatusRepository::class);
+        $repository->method('createOrUpdate')->willReturn(1);
+
+        $response = (new FolderController($repository))->updateStatusAction(
+            $this->createRequest(
+                ['identifier' => '1:/user_upload/', 'status' => '3', 'redirect' => 'https://evil.example/'],
+            ),
+        );
+
+        self::assertNotInstanceOf(RedirectResponse::class, $response);
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    private function enableFilelistSupport(): void
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')
+            ->with(Configuration::EXT_KEY)
+            ->willReturn(['enableFilelistSupport' => true]);
+        GeneralUtility::addInstance(ExtensionConfiguration::class, $extensionConfiguration);
+    }
+
+    /**
+     * @param array<string, mixed> $queryParams
+     */
+    private function createRequest(array $queryParams): ServerRequestInterface
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getParsedBody')->willReturn([]);
+        $request->method('getQueryParams')->willReturn($queryParams);
+
+        return $request;
+    }
+
+    private function createBackendUser(bool $isAdmin, bool $permitted): object
+    {
+        return new class($isAdmin, $permitted) {
+            /** @var array<string, mixed> */
+            public array $user = ['uid' => 1, 'tx_ximatypo3contentplanner_hide' => 0];
+
+            public function __construct(private readonly bool $isAdmin, private readonly bool $permitted) {}
+
+            public function isAdmin(): bool
+            {
+                return $this->isAdmin;
+            }
+
+            public function check(string $type, string $value): bool
+            {
+                return $this->permitted;
+            }
+        };
+    }
+}

--- a/Tests/Unit/Controller/FolderControllerTest.php
+++ b/Tests/Unit/Controller/FolderControllerTest.php
@@ -16,7 +16,6 @@ namespace Xima\XimaTypo3ContentPlanner\Tests\Unit\Controller;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
-use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Xima\XimaTypo3ContentPlanner\Configuration;
 use Xima\XimaTypo3ContentPlanner\Controller\FolderController;
@@ -84,24 +83,6 @@ final class FolderControllerTest extends TestCase
         $payload = json_decode((string) $response->getBody(), true);
         self::assertTrue($payload['success']);
         self::assertSame(42, $payload['uid']);
-    }
-
-    public function testUpdateStatusActionIgnoresExternalRedirect(): void
-    {
-        $GLOBALS['BE_USER'] = $this->createBackendUser(isAdmin: true, permitted: true);
-        $this->enableFilelistSupport();
-
-        $repository = $this->createMock(FolderStatusRepository::class);
-        $repository->method('createOrUpdate')->willReturn(1);
-
-        $response = (new FolderController($repository))->updateStatusAction(
-            $this->createRequest(
-                ['identifier' => '1:/user_upload/', 'status' => '3', 'redirect' => 'https://evil.example/'],
-            ),
-        );
-
-        self::assertNotInstanceOf(RedirectResponse::class, $response);
-        self::assertSame(200, $response->getStatusCode());
     }
 
     private function enableFilelistSupport(): void


### PR DESCRIPTION
## Summary

- The backend route \`ximatypo3contentplanner_folder_status_update\` was registered with \`access => 'public'\`, which disables backend user authentication **and** the CSRF token check. \`FolderController::updateStatusAction\` then performed a direct write (create/update folder status) with no permission check, accepting GET requests. This allowed unauthenticated status/assignee changes and CSRF against logged-in editors, plus an open redirect via the unvalidated \`redirect\` parameter.
- Removes the public access flag so TYPO3 enforces authentication and appends a CSRF token to all generated URLs of this route (the context-menu GET links keep working).
- Adds an explicit permission check in the controller mirroring the DataHandler path (content-status visibility + change/unset/assign permissions).
- Validates the \`redirect\` target with \`GeneralUtility::sanitizeLocalUrl()\` to close the open redirect.

## Changes

- \`Configuration/Backend/Routes.php\` - Remove \`access => public\` from the folder status update route
- \`Classes/Controller/FolderController.php\` - Authorize the change (visibility, status change/unset, self/other assignment) and sanitize the redirect target
- \`Tests/Unit/Controller/FolderControllerTest.php\` - Cover the route hardening, permission denial (403), permitted persistence, and external-redirect rejection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened folder status updates with explicit authorization checks to prevent unauthorized status/assignment changes.
  * Improved redirect handling by sanitizing redirect targets and avoiding unsafe external redirects.
  * Secured the folder status update endpoint by removing public route access.

* **Tests**
  * Added unit and functional test coverage for permission denial, successful updates, and redirect safety behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->