### PR TITLE
fix: escape record title and site in status filter widget to prevent stored XSS

### DIFF
--- a/Resources/Public/JavaScript/filter-status.js
+++ b/Resources/Public/JavaScript/filter-status.js
@@ -223,6 +223,16 @@ class FilterStatus {
     });
   }
 
+  static escapeHtml(value) {
+    return String(value ?? '').replace(/[&<>"']/g, (char) => ({
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;',
+    })[char]);
+  }
+
   static search(widget, queryArguments = {}, callback) {
     widget.querySelector('thead')?.classList.remove('content-planner-hide');
     widget.querySelector('.content-planner-widget__empty')?.classList.add('content-planner-hide');
@@ -254,8 +264,8 @@ class FilterStatus {
           }
 
           html += '<tr ' + (item.assignedToCurrentUser ? 'class="content-planner-row--current"' : '') + '>' +
-            '<td><a href="' + item.link + '">' + item.statusIcon + ' ' + item.recordIcon + ' <strong>' + item.title + '</strong></a></td>' +
-            '<td>' + (item.site ?? '') + '</td>' +
+            '<td><a href="' + item.link + '">' + item.statusIcon + ' ' + item.recordIcon + ' <strong>' + FilterStatus.escapeHtml(item.title) + '</strong></a></td>' +
+            '<td>' + FilterStatus.escapeHtml(item.site ?? '') + '</td>' +
             '<td><small title="' + item.updatedRaw + '">' + item.updated + '</small></td>' +
             '<td>' + (item.assignee ? (item.assigneeAvatar + item.assigneeName) : '') + '</td>' +
             '<td>' + comments + '</td>' +


### PR DESCRIPTION
## Summary

- The dashboard "Content Status" filter widget renders AJAX results by building an HTML string and assigning it to \`table.innerHTML\`. The record \`title\` (and \`site\`) are free-text, editor-controlled values (page title, content element header, file/folder name) and were injected unescaped, allowing stored XSS: an editor could place \`<img src=x onerror=...>\` in a title and have it execute in the backend session of any user (including admins) who opens the widget.
- Adds an \`escapeHtml\` helper and applies it to the two free-text fields before injection. Server-generated fields (icons, avatar, comment badges) and the assignee name (already \`htmlspecialchars\`-encoded server-side) are left untouched.

## Note on the server-rendered path

The same data is also rendered by the Fluid template \`ConfigurableContentStatusList.html\` via \`{item.title}\` / \`{item.site}\`, which Fluid auto-escapes. Escaping in \`StatusItem::toArray()\` would therefore double-escape titles in that path, so the fix is applied at the JavaScript sink instead.

## Testing

The change is confined to \`filter-status.js\`. The repository has no JavaScript test harness (only sprite generation via npm), so no unit test was added — introducing a JS test toolchain for a single helper is out of scope. The escaping logic was verified manually and the EditorConfig linter passes.

## Changes

- \`Resources/Public/JavaScript/filter-status.js\` - Add \`escapeHtml\` and escape \`item.title\` / \`item.site\` before \`innerHTML\` assignment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security when displaying filter search results by safely escaping titles and site names.
  * Prevented special characters and HTML content from being interpreted as markup in result rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->