### PR TITLE
fix: authorize comment retrieval to prevent reading foreign records' comments

### DIFF
--- a/Classes/Controller/RecordController.php
+++ b/Classes/Controller/RecordController.php
@@ -105,10 +105,27 @@ class RecordController extends ActionController
 
     public function commentsAction(ServerRequestInterface $request): JsonResponse
     {
-        $recordId = (int) $request->getQueryParams()['uid'];
-        $recordTable = $request->getQueryParams()['table'];
+        $recordId = (int) ($request->getQueryParams()['uid'] ?? 0);
+        $recordTable = $request->getQueryParams()['table'] ?? '';
         $sortComments = $request->getQueryParams()['sortComments'] ?? 'DESC';
         $showResolvedComments = (bool) ($request->getQueryParams()['showResolvedComments'] ?? false);
+
+        if ('' === $recordTable || 0 === $recordId) {
+            return new JsonResponse(['error' => 'Missing required parameters'], 400);
+        }
+
+        if (!PermissionUtility::checkContentStatusVisibility()) {
+            return new JsonResponse(['error' => 'Access denied'], 403);
+        }
+
+        $record = $this->recordRepository->findByUid($recordTable, $recordId, ignoreVisibilityRestriction: true);
+        if (!$record) {
+            return new JsonResponse(['error' => 'Record not found'], 404);
+        }
+
+        if (!PermissionUtility::checkAccessForRecord($recordTable, $record)) {
+            return new JsonResponse(['error' => 'Access denied'], 403);
+        }
 
         /** @var BackendUserAuthentication $backendUser */
         $backendUser = $GLOBALS['BE_USER'];

--- a/Tests/Functional/Controller/RecordControllerTest.php
+++ b/Tests/Functional/Controller/RecordControllerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Tests\Functional\Controller;
+
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Core\RequestId;
+use Xima\XimaTypo3ContentPlanner\Controller\RecordController;
+use Xima\XimaTypo3ContentPlanner\Domain\Repository\{BackendUserRepository, CommentRepository, RecordRepository};
+use Xima\XimaTypo3ContentPlanner\Tests\Functional\AbstractFunctionalTestCase;
+
+/**
+ * RecordControllerTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class RecordControllerTest extends AbstractFunctionalTestCase
+{
+    #[Test]
+    public function commentsActionReturnsBadRequestWhenParametersMissing(): void
+    {
+        $this->loginBackendUser(1);
+
+        $response = $this->createController()->commentsAction($this->createRequest([]));
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function commentsActionReturnsNotFoundForUnknownRecord(): void
+    {
+        $this->loginBackendUser(1);
+
+        $response = $this->createController()->commentsAction(
+            $this->createRequest(['table' => 'pages', 'uid' => 99999]),
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function commentsActionDeniesUserWithoutContentPlannerAccess(): void
+    {
+        // Editor (uid 2) is a non-admin without any content planner permission.
+        $this->loginBackendUser(2);
+
+        $response = $this->createController()->commentsAction(
+            $this->createRequest(['table' => 'pages', 'uid' => 1]),
+        );
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    private function createController(): RecordController
+    {
+        return new RecordController(
+            $this->get(RecordRepository::class),
+            $this->get(CommentRepository::class),
+            $this->get(BackendUserRepository::class),
+            $this->get(RequestId::class),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $queryParams
+     */
+    private function createRequest(array $queryParams): ServerRequestInterface
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn($queryParams);
+
+        return $request;
+    }
+}


### PR DESCRIPTION
## Summary

- \`RecordController::commentsAction\` (AJAX route \`ximatypo3contentplanner_comments\`) performed no authorization: any authenticated backend user could pass an arbitrary \`table\`/\`uid\` and read all comments, to-dos and threads of any record — an IDOR exposing potentially confidential editorial discussions.
- Adds the same guard sequence already used by \`shareAction\`: required-parameter validation (400), content-status visibility (403), record existence (404), and per-record access check via \`PermissionUtility::checkAccessForRecord\` (403).

## Changes

- \`Classes/Controller/RecordController.php\` - Validate parameters and authorize the record before returning its comments
- \`Tests/Functional/Controller/RecordControllerTest.php\` - Cover missing parameters (400), unknown record (404), and a user without content planner access (403)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment loading checks so invalid or missing record parameters are rejected earlier.
  * Requests for unknown records now consistently return the appropriate not-found response.
  * Access restrictions for comment viewing are enforced more reliably.

* **Tests**
  * Added functional coverage for missing parameters, unknown records, and insufficient access permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->