### PR TITLE
fix: whitelist comment sort direction to prevent SQL injection via ORDER BY

### DIFF
--- a/Classes/Domain/Repository/CommentRepository.php
+++ b/Classes/Domain/Repository/CommentRepository.php
@@ -48,6 +48,9 @@ class CommentRepository
      */
     public function findAllByRecord(int $id, string $table, bool $raw = false, string $sortDirection = 'DESC', bool $showResolved = false): array
     {
+        // Whitelist the sort direction: QueryBuilder::orderBy() does not quote the direction argument.
+        $sortDirection = 'ASC' === strtoupper($sortDirection) ? 'ASC' : 'DESC';
+
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
 
         $replyTable = self::TABLE.'_replies';

--- a/Tests/Functional/Repository/CommentRepositoryTest.php
+++ b/Tests/Functional/Repository/CommentRepositoryTest.php
@@ -99,6 +99,26 @@ final class CommentRepositoryTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function findAllByRecordNormalizesLowercaseSortDirection(): void
+    {
+        $result = $this->subject->findAllByRecord(10, 'pages', false, 'asc');
+
+        self::assertSame(1, (int) $result[0]->data['uid']);
+        self::assertSame(2, (int) $result[1]->data['uid']);
+    }
+
+    #[Test]
+    public function findAllByRecordNeutralizesMaliciousSortDirection(): void
+    {
+        // An SQL injection attempt in the (unquoted) ORDER BY direction must be rejected
+        // and fall back to the default DESC ordering instead of reaching the database.
+        $result = $this->subject->findAllByRecord(10, 'pages', false, 'DESC; SELECT SLEEP(5)');
+
+        self::assertSame(2, (int) $result[0]->data['uid']);
+        self::assertSame(1, (int) $result[1]->data['uid']);
+    }
+
+    #[Test]
     public function findAllByRecordReturnsEmptyArrayForUnknownRecord(): void
     {
         self::assertSame([], $this->subject->findAllByRecord(999, 'pages'));


### PR DESCRIPTION
## Summary

- \`CommentRepository::findAllByRecord\` passed a request-controlled \`sortDirection\` straight into \`QueryBuilder::orderBy()\`. The QueryBuilder quotes the column name but **not** the direction argument, so the value was concatenated raw into the \`ORDER BY\` clause — an SQL injection vector (e.g. boolean/time-based) reachable via the \`sortComments\` query parameter of the comments AJAX route.
- Normalizes the value at the method entry to a strict \`ASC\`/\`DESC\` whitelist, which also covers the replies sub-query that receives the same direction.

## Changes

- \`Classes/Domain/Repository/CommentRepository.php\` - Whitelist \`sortDirection\` to \`ASC\`/\`DESC\`
- \`Tests/Functional/Repository/CommentRepositoryTest.php\` - Cover lowercase normalization and neutralization of an injection payload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment sorting to handle sort directions consistently.
  * Prevented unsafe or invalid sorting input from affecting comment queries.
  * Preserved the default descending order when an unsupported direction is provided.

* **Tests**
  * Added coverage for lowercase sort directions and malicious sorting input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->