### PR TITLE
fix: authorize assignee selection to prevent record enumeration and user disclosure

### DIFF
--- a/Classes/Controller/RecordController.php
+++ b/Classes/Controller/RecordController.php
@@ -145,14 +145,26 @@ class RecordController extends ActionController
      */
     public function assigneeSelectionAction(ServerRequestInterface $request): ResponseInterface
     {
-        $recordId = (int) $request->getQueryParams()['uid'];
-        $recordTable = $request->getQueryParams()['table'];
+        $recordId = (int) ($request->getQueryParams()['uid'] ?? 0);
+        $recordTable = $request->getQueryParams()['table'] ?? '';
         $currentAssignee = (int) ($request->getQueryParams()['currentAssignee'] ?? 0);
+
+        if ('' === $recordTable || 0 === $recordId) {
+            return new JsonResponse(['error' => 'Missing required parameters'], 400);
+        }
+
+        if (!PermissionUtility::checkContentStatusVisibility()) {
+            return new JsonResponse(['error' => 'Access denied'], 403);
+        }
 
         $record = $this->recordRepository->findByUid($recordTable, $recordId, ignoreVisibilityRestriction: true);
 
         if (!$record) {
             return new JsonResponse(['error' => 'Record not found'], 404);
+        }
+
+        if (!PermissionUtility::checkAccessForRecord($recordTable, $record)) {
+            return new JsonResponse(['error' => 'Access denied'], 403);
         }
 
         $permissions = $this->getAssignmentPermissions();

--- a/Tests/Functional/Controller/RecordControllerAssigneeTest.php
+++ b/Tests/Functional/Controller/RecordControllerAssigneeTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Tests\Functional\Controller;
+
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Core\RequestId;
+use Xima\XimaTypo3ContentPlanner\Controller\RecordController;
+use Xima\XimaTypo3ContentPlanner\Domain\Repository\{BackendUserRepository, CommentRepository, RecordRepository};
+use Xima\XimaTypo3ContentPlanner\Tests\Functional\AbstractFunctionalTestCase;
+
+/**
+ * RecordControllerAssigneeTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class RecordControllerAssigneeTest extends AbstractFunctionalTestCase
+{
+    #[Test]
+    public function assigneeSelectionActionReturnsBadRequestWhenParametersMissing(): void
+    {
+        $this->loginBackendUser(1);
+
+        $response = $this->createController()->assigneeSelectionAction($this->createRequest([]));
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function assigneeSelectionActionDeniesUserWithoutContentPlannerAccess(): void
+    {
+        // Editor (uid 2) is a non-admin without any content planner permission and must not
+        // be able to probe record existence or retrieve the backend user list.
+        $this->loginBackendUser(2);
+
+        $response = $this->createController()->assigneeSelectionAction(
+            $this->createRequest(['table' => 'pages', 'uid' => 1]),
+        );
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    private function createController(): RecordController
+    {
+        return new RecordController(
+            $this->get(RecordRepository::class),
+            $this->get(CommentRepository::class),
+            $this->get(BackendUserRepository::class),
+            $this->get(RequestId::class),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $queryParams
+     */
+    private function createRequest(array $queryParams): ServerRequestInterface
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn($queryParams);
+
+        return $request;
+    }
+}


### PR DESCRIPTION
## Summary

- \`RecordController::assigneeSelectionAction\` looked up the record with \`ignoreVisibilityRestriction: true\` and returned the full backend user list without any authorization. Any authenticated backend user could therefore (a) enumerate the existence of arbitrary records in arbitrary tables via 404 vs. 200, and (b) retrieve the list of backend users — regardless of access to the concrete record.
- Adds parameter validation (400), content-status visibility (403) and a per-record access check via \`PermissionUtility::checkAccessForRecord\` (403), matching \`shareAction\`.

## Changes

- \`Classes/Controller/RecordController.php\` - Validate parameters and authorize the record before building the assignee selection
- \`Tests/Functional/Controller/RecordControllerAssigneeTest.php\` - Cover missing parameters (400) and a user without content planner access (403)