### PR TITLE
fix: validate message redirect target to prevent open redirect

### DIFF
--- a/Classes/Controller/ProxyController.php
+++ b/Classes/Controller/ProxyController.php
@@ -150,6 +150,11 @@ class ProxyController extends ActionController
 
         $redirect = $request->getQueryParams()['redirect'] ?? null;
         if (null !== $redirect) {
+            $redirect = GeneralUtility::sanitizeLocalUrl($redirect);
+            if ('' === $redirect) {
+                return new JsonResponse(['error' => 'Invalid redirect target'], 400);
+            }
+
             $message = $this->getMessageByDotNotation($messagePath);
             if (null === $message) {
                 return new JsonResponse(['error' => 'Invalid message path'], 400);

--- a/Tests/Functional/Controller/ProxyControllerTest.php
+++ b/Tests/Functional/Controller/ProxyControllerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Tests\Functional\Controller;
+
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Messaging\FlashMessageService;
+use Xima\XimaTypo3ContentPlanner\Controller\ProxyController;
+use Xima\XimaTypo3ContentPlanner\Tests\Functional\AbstractFunctionalTestCase;
+
+/**
+ * ProxyControllerTest.
+ *
+ * The redirect validation uses GeneralUtility::sanitizeLocalUrl(), which needs an initialized
+ * Environment — only available in the functional bootstrap, hence this case lives here.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class ProxyControllerTest extends AbstractFunctionalTestCase
+{
+    #[Test]
+    public function messageActionRejectsExternalRedirect(): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn([
+            'message' => 'status.changed',
+            'redirect' => 'https://evil.example/',
+        ]);
+
+        $controller = new ProxyController($this->get(FlashMessageService::class));
+
+        self::assertSame(400, $controller->messageAction($request)->getStatusCode());
+    }
+}

--- a/Tests/Unit/Controller/ProxyControllerTest.php
+++ b/Tests/Unit/Controller/ProxyControllerTest.php
@@ -32,6 +32,29 @@ final class ProxyControllerTest extends TestCase
         unset($GLOBALS['BE_USER']);
     }
 
+    public function testMessageActionRejectsExternalRedirect(): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn([
+            'message' => 'status.changed',
+            'redirect' => 'https://evil.example/',
+        ]);
+
+        $response = $this->createController()->messageAction($request);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    public function testMessageActionReturnsBadRequestWhenMessageMissing(): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn([]);
+
+        $response = $this->createController()->messageAction($request);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
     public function testCloseDocumentActionRemovesCommentEntriesAndKeepsForeignTables(): void
     {
         $backendUser = $this->createMockBackendUser([

--- a/Tests/Unit/Controller/ProxyControllerTest.php
+++ b/Tests/Unit/Controller/ProxyControllerTest.php
@@ -32,19 +32,6 @@ final class ProxyControllerTest extends TestCase
         unset($GLOBALS['BE_USER']);
     }
 
-    public function testMessageActionRejectsExternalRedirect(): void
-    {
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request->method('getQueryParams')->willReturn([
-            'message' => 'status.changed',
-            'redirect' => 'https://evil.example/',
-        ]);
-
-        $response = $this->createController()->messageAction($request);
-
-        self::assertSame(400, $response->getStatusCode());
-    }
-
     public function testMessageActionReturnsBadRequestWhenMessageMissing(): void
     {
         $request = $this->createMock(ServerRequestInterface::class);


### PR DESCRIPTION
## Summary

- \`ProxyController::messageAction\` (public route \`ximatypo3contentplanner_message\`) passed the \`redirect\` query parameter straight into a \`RedirectResponse\` without validation, allowing an open redirect to any external host (e.g. \`?message=status.changed&redirect=https://evil.example\`) for phishing/redirect chaining.
- Validates the target with \`GeneralUtility::sanitizeLocalUrl()\`; non-local targets are now rejected with a 400 before any redirect happens. Legitimate internal redirects (built via the backend UriBuilder) are unaffected.

## Changes

- \`Classes/Controller/ProxyController.php\` - Sanitize the redirect target and reject non-local URLs
- \`Tests/Unit/Controller/ProxyControllerTest.php\` - Cover rejection of an external redirect and the missing-message case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redirect validation to reject unsafe or invalid redirect targets with a clear `400` error response.
  * Requests missing a required message now return a `400` error instead of proceeding.

* **Tests**
  * Added coverage for external redirect rejection and missing-message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->