### PR TITLE
fix: restrict record lookup to registered content planner tables

### DIFF
--- a/Classes/Domain/Repository/RecordRepository.php
+++ b/Classes/Domain/Repository/RecordRepository.php
@@ -24,6 +24,7 @@ use Xima\XimaTypo3ContentPlanner\Utility\ExtensionUtility;
 use Xima\XimaTypo3ContentPlanner\Utility\Security\PermissionUtility;
 
 use function count;
+use function in_array;
 use function is_array;
 use function sprintf;
 
@@ -133,6 +134,13 @@ class RecordRepository
         if (!(bool) $table && !(bool) $uid) {
             return null;
         }
+
+        // Only registered content planner record tables may be queried through this method
+        // (the table name flows into getQueryBuilderForTable()/getTitleField() from request input).
+        if (null === $table || !in_array($table, ExtensionUtility::getRecordTables(), true)) {
+            return null;
+        }
+
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
 
         if ($ignoreVisibilityRestriction) {

--- a/Tests/Functional/Repository/RecordRepositoryTest.php
+++ b/Tests/Functional/Repository/RecordRepositoryTest.php
@@ -54,6 +54,14 @@ final class RecordRepositoryTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function findByUidReturnsNullForUnregisteredTable(): void
+    {
+        // be_users is not a registered content planner record table and must be rejected
+        // by the whitelist regardless of whether a matching row exists.
+        self::assertNull($this->subject->findByUid('be_users', 1));
+    }
+
+    #[Test]
     public function findByUidExcludesDeletedRecordByDefault(): void
     {
         self::assertFalse($this->subject->findByUid('pages', 5));


### PR DESCRIPTION
## Summary

- \`RecordRepository::findByUid\` passed a request-controlled \`table\` name straight into \`getQueryBuilderForTable()\` and \`getTitleField()\` (\`$GLOBALS['TCA'][$table]['ctrl']['label']\`) without checking it against the registered content planner tables. Arbitrary table names could trigger DBAL errors / information disclosure and gave the read AJAX endpoints (\`share\`, \`comments\`, \`assignees\`) an uncontrolled table surface.
- Adds a central whitelist check against \`ExtensionUtility::getRecordTables()\` at this data-layer sink, so all callers (including the AJAX endpoints) are protected without duplicating the check per action. Unregistered tables now yield \`null\` (the controllers already translate that to a 404).

## Changes

- \`Classes/Domain/Repository/RecordRepository.php\` - Reject non-registered tables in \`findByUid\`
- \`Tests/Functional/Repository/RecordRepositoryTest.php\` - Cover rejection of an unregistered table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved record lookups by rejecting queries for unregistered tables.
  * Invalid or unsupported table names now return no result instead of triggering a database query.

* **Tests**
  * Added coverage verifying that lookups against unregistered tables are safely rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->