### PR TITLE
perf: add database indexes for status, assignee and comment lookups

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -3,6 +3,8 @@ CREATE TABLE pages
 	tx_ximatypo3contentplanner_status   int(11) DEFAULT NULL,
 	tx_ximatypo3contentplanner_assignee int(11) DEFAULT NULL,
 	tx_ximatypo3contentplanner_comments int(11) unsigned default '0' not null,
+	KEY contentplanner_status (tx_ximatypo3contentplanner_status),
+	KEY contentplanner_assignee (tx_ximatypo3contentplanner_assignee)
 );
 
 CREATE TABLE be_users
@@ -32,7 +34,9 @@ CREATE TABLE tx_ximatypo3contentplanner_comment
 	todo_resolved int(11) unsigned NOT NULL DEFAULT 0,
 	todo_total    int(11) unsigned NOT NULL DEFAULT 0,
 	parent_uid    int(11) DEFAULT '0' NOT NULL,
-	PRIMARY KEY (uid)
+	PRIMARY KEY (uid),
+	KEY foreign_record (foreign_table(64), foreign_uid),
+	KEY parent (parent_uid)
 );
 
 CREATE TABLE tx_ximatypo3contentplanner_domain_model_status
@@ -53,14 +57,18 @@ CREATE TABLE tt_content
 (
     tx_ximatypo3contentplanner_status   int(11) DEFAULT NULL,
     tx_ximatypo3contentplanner_assignee int(11) DEFAULT NULL,
-    tx_ximatypo3contentplanner_comments int(11) unsigned DEFAULT '0' NOT NULL
+    tx_ximatypo3contentplanner_comments int(11) unsigned DEFAULT '0' NOT NULL,
+    KEY contentplanner_status (tx_ximatypo3contentplanner_status),
+    KEY contentplanner_assignee (tx_ximatypo3contentplanner_assignee)
 );
 
 CREATE TABLE sys_file_metadata
 (
 	tx_ximatypo3contentplanner_status   int(11) DEFAULT NULL,
 	tx_ximatypo3contentplanner_assignee int(11) DEFAULT NULL,
-	tx_ximatypo3contentplanner_comments int(11) unsigned DEFAULT '0' NOT NULL
+	tx_ximatypo3contentplanner_comments int(11) unsigned DEFAULT '0' NOT NULL,
+	KEY contentplanner_status (tx_ximatypo3contentplanner_status),
+	KEY contentplanner_assignee (tx_ximatypo3contentplanner_assignee)
 );
 
 CREATE TABLE tx_ximatypo3contentplanner_folder


### PR DESCRIPTION
## Summary

- The tracking columns \`tx_ximatypo3contentplanner_status\` / \`_assignee\` on \`pages\`, \`tt_content\` and \`sys_file_metadata\` had no index, so every status/assignee filter and every dashboard-widget UNION sub-query caused a full table scan. On large installations (100k+ \`tt_content\` rows) that is several full scans per dashboard render.
- The comment table (\`tx_ximatypo3contentplanner_comment\`) had only its primary key, although it is filtered almost everywhere on \`foreign_table\`+\`foreign_uid\` and \`parent_uid\` — including correlated to-do sub-queries that scale quadratically without an index.
- Adds selective indexes for these access patterns. Typically only a small fraction of records are tracked, so the status/assignee indexes are highly selective.

## Changes

- \`ext_tables.sql\` - Add \`contentplanner_status\` / \`contentplanner_assignee\` indexes on \`pages\`, \`tt_content\`, \`sys_file_metadata\`; add \`foreign_record (foreign_table, foreign_uid)\` and \`parent (parent_uid)\` indexes on the comment table

## Testing

Schema-only change (no behavior change). Verified by the functional test suite, which builds the schema from \`ext_tables.sql\` on every run and passes; the index prefix length follows the existing \`folder_lookup\` key and is handled by the SQLite test driver.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved database performance for content planning by adding indexes for statuses, assignees, parent comments, and related records.
  * Standardized comment tracking fields across content and file metadata records.
  * Ensured key database constraints are consistently defined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->