### PR TITLE
fix: correctly build page-scoped cache tag on record changes

### DIFF
--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -29,7 +29,6 @@ use Xima\XimaTypo3ContentPlanner\Utility\ExtensionUtility;
 use Xima\XimaTypo3ContentPlanner\Utility\Security\PermissionUtility;
 
 use function array_key_exists;
-use function in_array;
 
 /**
  * DataHandlerHook.
@@ -168,7 +167,7 @@ final readonly class DataHandlerHook // @phpstan-ignore-line complexity.classLik
     {
         $rawTags = $params['tags'] ?? [];
         $tags = array_is_list($rawTags) ? $rawTags : array_keys($rawTags);
-        if (in_array('uid_page', $params, true) && in_array('table', $params, true)) {
+        if (array_key_exists('uid_page', $params) && array_key_exists('table', $params)) {
             $tags[] = $params['table'].'__pageId__'.$params['uid_page'];
         }
         $this->cache->flushByTags($tags);

--- a/Tests/Unit/Hooks/DataHandlerHookTest.php
+++ b/Tests/Unit/Hooks/DataHandlerHookTest.php
@@ -57,10 +57,34 @@ final class DataHandlerHookTest extends TestCase
         );
     }
 
-    private function createHook(): DataHandlerHook
+    public function testClearCachePostProcAddsPageIdTagWhenTableAndUidPagePresent(): void
+    {
+        $cache = $this->createMock(FrontendInterface::class);
+        $cache->expects(self::once())
+            ->method('flushByTags')
+            ->with(self::identicalTo(['existing', 'pages__pageId__5']));
+
+        $this->createHook($cache)->clearCachePostProc([
+            'tags' => ['existing'],
+            'table' => 'pages',
+            'uid_page' => 5,
+        ]);
+    }
+
+    public function testClearCachePostProcForwardsOnlyCoreTagsWhenPageInfoAbsent(): void
+    {
+        $cache = $this->createMock(FrontendInterface::class);
+        $cache->expects(self::once())
+            ->method('flushByTags')
+            ->with(self::identicalTo(['existing']));
+
+        $this->createHook($cache)->clearCachePostProc(['tags' => ['existing']]);
+    }
+
+    private function createHook(?FrontendInterface $cache = null): DataHandlerHook
     {
         return new DataHandlerHook(
-            $this->createMock(FrontendInterface::class),
+            $cache ?? $this->createMock(FrontendInterface::class),
             $this->createMock(StatusChangeManager::class),
             $this->createMock(RecordRepository::class),
             $this->createMock(CommentRepository::class),


### PR DESCRIPTION
## Summary

- \`DataHandlerHook::clearCachePostProc\` guarded the page-scoped tag with \`in_array('uid_page', \$params, true)\` / \`in_array('table', \$params, true)\`, which checks the array **values** although \`uid_page\` and \`table\` are array **keys**. The condition was therefore effectively never true, so the \`<table>__pageId__<pid>\` tag produced by \`RecordRepository::collectCacheTags()\` was never flushed — leaving stale \`findByPid()\` cache entries after record changes.
- Uses \`array_key_exists()\` so the tag is built as intended; removes the now-unused \`in_array\` import.

## Changes

- \`Classes/Hooks/DataHandlerHook.php\` - Use \`array_key_exists\` for the \`uid_page\`/\`table\` check; drop unused import
- \`Tests/Unit/Hooks/DataHandlerHookTest.php\` - Cover tag construction with and without page information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache invalidation when page metadata is provided, ensuring related page-specific cache entries are flushed.
  * Preserved standard cache-tag flushing when page metadata is absent.

* **Tests**
  * Added coverage for page-specific cache invalidation and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->