### PR TITLE
perf: memoize status lookups per request in StatusRepository

### DIFF
--- a/Classes/Domain/Repository/StatusRepository.php
+++ b/Classes/Domain/Repository/StatusRepository.php
@@ -20,6 +20,7 @@ use TYPO3\CMS\Extbase\Persistence\{QueryInterface, Repository};
 use Xima\XimaTypo3ContentPlanner\Configuration;
 use Xima\XimaTypo3ContentPlanner\Domain\Model\Status;
 
+use function array_key_exists;
 use function is_array;
 use function sprintf;
 
@@ -36,6 +37,18 @@ class StatusRepository extends Repository
     protected $defaultOrderings = [
         'sorting' => QueryInterface::ORDER_ASCENDING,
     ];
+
+    /**
+     * Request-level memoization: the repository is a singleton, so this avoids repeated
+     * cache backend reads (each a database query with the default backend) when the same
+     * status is resolved many times per request, e.g. once per page tree item.
+     *
+     * @var array<int, Status|null>
+     */
+    private array $runtimeStatusCache = [];
+
+    /** @var array<int, Status>|null */
+    private ?array $runtimeAllCache = null;
 
     public function __construct(private readonly FrontendInterface $cache)
     {
@@ -56,25 +69,33 @@ class StatusRepository extends Repository
      */
     public function findAll(): array
     {
+        if (null !== $this->runtimeAllCache) {
+            return $this->runtimeAllCache;
+        }
+
         $cacheIdentifier = sprintf('%s--status--all', Configuration::CACHE_IDENTIFIER);
         $cachedResult = $this->cache->get($cacheIdentifier);
         if (is_array($cachedResult)) {
-            return $cachedResult;
+            return $this->runtimeAllCache = $cachedResult;
         }
 
         $query = $this->createQuery();
         $result = $query->execute()->toArray();
         $this->cache->set($cacheIdentifier, $result, $this->collectCacheTags($result));
 
-        return $result;
+        return $this->runtimeAllCache = $result;
     }
 
     public function findByUid($uid): ?Status
     {
+        if (array_key_exists($uid, $this->runtimeStatusCache)) {
+            return $this->runtimeStatusCache[$uid];
+        }
+
         $cacheIdentifier = sprintf('%s--status--%s', Configuration::CACHE_IDENTIFIER, $uid);
         $cachedResult = $this->cache->get($cacheIdentifier);
         if ($cachedResult instanceof Status) {
-            return $cachedResult;
+            return $this->runtimeStatusCache[$uid] = $cachedResult;
         }
 
         $query = $this->createQuery();
@@ -83,11 +104,11 @@ class StatusRepository extends Repository
         $result = $query->execute()->getFirst();
 
         if (null === $result) {
-            return null;
+            return $this->runtimeStatusCache[$uid] = null;
         }
         $this->cache->set($cacheIdentifier, $result, $this->collectCacheTags([$result]));
 
-        return $result;
+        return $this->runtimeStatusCache[$uid] = $result;
     }
 
     public function findByTitle(string $title): ?Status

--- a/Tests/Functional/Repository/StatusRepositoryTest.php
+++ b/Tests/Functional/Repository/StatusRepositoryTest.php
@@ -78,6 +78,24 @@ final class StatusRepositoryTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function findByUidReturnsSameInstanceOnSecondCallViaRuntimeCache(): void
+    {
+        $first = $this->subject->findByUid(2);
+        $second = $this->subject->findByUid(2);
+
+        // Without runtime memoization the second call would be served from the (serializing)
+        // cache backend and thus return a different object instance.
+        self::assertSame($first, $second);
+    }
+
+    #[Test]
+    public function findByUidMemoizesUnknownUid(): void
+    {
+        self::assertNull($this->subject->findByUid(999));
+        self::assertNull($this->subject->findByUid(999));
+    }
+
+    #[Test]
     public function findByTitleReturnsMatchingStatus(): void
     {
         $status = $this->subject->findByTitle('Done');


### PR DESCRIPTION
## Summary

- \`StatusRepository::findByUid\`/\`findAll\` are backed by the TYPO3 cache, but with the default database cache backend every \`get()\` is itself a database query. The page tree listener resolves a status once per tree item, so a tree with hundreds of nodes issued hundreds of cache-table SELECTs per render, although only a handful of distinct statuses exist.
- Adds a request-level in-memory memoization. \`Repository\` is a singleton, so the map is shared across the whole request; it is naturally reset per functional test because the container is rebuilt.

## Changes

- \`Classes/Domain/Repository/StatusRepository.php\` - Memoize \`findByUid\` (including misses) and \`findAll\` in instance-level runtime caches
- \`Tests/Functional/Repository/StatusRepositoryTest.php\` - Assert the second lookup returns the same instance and unknown UIDs are memoized