### PR TITLE
perf: memoize backend user display names per request

### DIFF
--- a/Classes/Domain/Repository/BackendUserRepository.php
+++ b/Classes/Domain/Repository/BackendUserRepository.php
@@ -17,6 +17,7 @@ use Doctrine\DBAL\Exception;
 use TYPO3\CMS\Core\Database\{Connection, ConnectionPool};
 use Xima\XimaTypo3ContentPlanner\Configuration;
 
+use function array_key_exists;
 use function in_array;
 
 /**
@@ -27,6 +28,15 @@ use function in_array;
  */
 class BackendUserRepository
 {
+    /**
+     * Request-level memoization of resolved display names, keyed by user uid.
+     * The same author/assignee is typically rendered many times per request
+     * (e.g. once per comment or list row).
+     *
+     * @var array<int, string>
+     */
+    private array $usernameCache = [];
+
     public function __construct(private readonly ConnectionPool $connectionPool) {}
 
     /**
@@ -135,6 +145,11 @@ class BackendUserRepository
         if (!(bool) $uid) {
             return '';
         }
+
+        if (array_key_exists($uid, $this->usernameCache)) {
+            return $this->usernameCache[$uid];
+        }
+
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('be_users');
 
         $userRecord = $queryBuilder
@@ -145,16 +160,17 @@ class BackendUserRepository
             )
             ->executeQuery()->fetchAssociative();
 
+        $user = '';
         if ($userRecord) {
             $user = $userRecord['username'];
             if ((bool) $userRecord['realName']) {
                 $user = $userRecord['realName'].' ('.$user.')';
             }
 
-            return htmlspecialchars((string) $user, \ENT_QUOTES | \ENT_HTML5, 'UTF-8');
+            $user = htmlspecialchars((string) $user, \ENT_QUOTES | \ENT_HTML5, 'UTF-8');
         }
 
-        return '';
+        return $this->usernameCache[$uid] = $user;
     }
 
     /**

--- a/Tests/Functional/Repository/BackendUserRepositoryTest.php
+++ b/Tests/Functional/Repository/BackendUserRepositoryTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Xima\XimaTypo3ContentPlanner\Tests\Functional\Repository;
 
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use Xima\XimaTypo3ContentPlanner\Domain\Repository\BackendUserRepository;
 use Xima\XimaTypo3ContentPlanner\Tests\Functional\AbstractFunctionalTestCase;
 
@@ -85,6 +86,19 @@ final class BackendUserRepositoryTest extends AbstractFunctionalTestCase
     public function getUsernameByUidReturnsEmptyStringForNull(): void
     {
         self::assertSame('', $this->subject->getUsernameByUid(null));
+    }
+
+    #[Test]
+    public function getUsernameByUidMemoizesResultForRequest(): void
+    {
+        $first = $this->subject->getUsernameByUid(1);
+        self::assertSame('Administrator (admin)', $first);
+
+        // A non-memoized second lookup would reflect this database change.
+        $this->get(ConnectionPool::class)->getConnectionForTable('be_users')
+            ->update('be_users', ['realName' => 'Changed Name'], ['uid' => 1]);
+
+        self::assertSame($first, $this->subject->getUsernameByUid(1));
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- \`BackendUserRepository::getUsernameByUid\` ran a \`be_users\` query on every call and was invoked once per comment, reply and list row — the same author/assignee is usually rendered many times per request (e.g. 30–60 near-identical queries for a comment modal).
- Adds a request-level in-memory cache keyed by user uid (the repository is a shared service), covering both resolved names and misses.

## Changes

- \`Classes/Domain/Repository/BackendUserRepository.php\` - Memoize resolved display names per uid
- \`Tests/Functional/Repository/BackendUserRepositoryTest.php\` - Assert the value is memoized within a request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved repeated username lookups during a request by reusing previously resolved values.
  * Preserved consistent display names, including HTML escaping and empty results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->