### PR TITLE
perf: limit backend user findAll to display fields and exclude deleted users

### DIFF
--- a/Classes/Domain/Repository/BackendUserRepository.php
+++ b/Classes/Domain/Repository/BackendUserRepository.php
@@ -39,8 +39,9 @@ class BackendUserRepository
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('be_users');
 
         return $queryBuilder
-            ->select('*')
+            ->select('uid', 'username', 'realName')
             ->from('be_users')
+            ->where($queryBuilder->expr()->eq('deleted', 0))
             ->executeQuery()->fetchAllAssociative();
     }
 

--- a/Tests/Functional/Repository/BackendUserRepositoryTest.php
+++ b/Tests/Functional/Repository/BackendUserRepositoryTest.php
@@ -46,6 +46,26 @@ final class BackendUserRepositoryTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function findAllExcludesDeletedUsers(): void
+    {
+        $usernames = array_map(
+            static fn (array $row): string => $row['username'],
+            $this->subject->findAll(),
+        );
+
+        self::assertNotContains('deleted', $usernames);
+    }
+
+    #[Test]
+    public function findAllSelectsOnlyDisplayFields(): void
+    {
+        $result = $this->subject->findAll();
+
+        self::assertNotEmpty($result);
+        self::assertSame(['uid', 'username', 'realName'], array_keys($result[0]));
+    }
+
+    #[Test]
     public function findByUidReturnsMatchingUser(): void
     {
         $result = $this->subject->findByUid(1);


### PR DESCRIPTION
## Summary

- \`BackendUserRepository::findAll\` selected \`*\` (including the potentially large \`uc\` blob) and had no \`deleted\` filter, so deleted backend users showed up in the assignee filter options. Both consumers (\`ConfigurableContentStatusWidget::getAssigneeOptions\` and \`ContentStatusDataProvider::getUsers\`) only use \`uid\`, \`username\` and \`realName\`.
- Narrows the projection to those three columns and excludes deleted users.

## Changes

- \`Classes/Domain/Repository/BackendUserRepository.php\` - Select only display fields and filter \`deleted = 0\` in \`findAll\`
- \`Tests/Functional/Repository/BackendUserRepositoryTest.php\` - Assert deleted users are excluded and only display fields are returned