### PR TITLE
refactor: use executeStatement for status-clearing update query

### DIFF
--- a/Classes/Manager/StatusChangeManager.php
+++ b/Classes/Manager/StatusChangeManager.php
@@ -113,7 +113,7 @@ class StatusChangeManager
             );
         }
 
-        $queryBuilder->executeQuery();
+        $queryBuilder->executeStatement();
     }
 
     /**


### PR DESCRIPTION
## Summary

- \`StatusChangeManager::clearStatusOfExtensionRecords\` issued an \`UPDATE\` via \`executeQuery()\`, which is the API meant for result-returning statements. Uses \`executeStatement()\` instead, which is the correct API for write statements and returns the affected row count.

## Testing

Behavior is covered by the existing \`StatusChangeManagerTest\` cases (\`clearStatusOfExtensionRecords\` for all records, by pid and by status), which continue to pass.

## Changes

- \`Classes/Manager/StatusChangeManager.php\` - Use \`executeStatement()\` for the update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when clearing extension record statuses during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->