### PR TITLE
perf: count status overview via aggregated query instead of capped full fetch

### DIFF
--- a/Classes/Domain/Repository/RecordRepository.php
+++ b/Classes/Domain/Repository/RecordRepository.php
@@ -71,6 +71,41 @@ class RecordRepository
     }
 
     /**
+     * Count records that carry a status, grouped by status uid, across all tracked tables.
+     *
+     * @return array<int, int> map of status uid => record count
+     *
+     * @throws Exception
+     */
+    public function countRecordsByStatus(): array
+    {
+        $statusField = Configuration::FIELD_STATUS;
+        $counts = [];
+
+        foreach (ExtensionUtility::getRecordTables() as $table) {
+            $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
+            $rows = $queryBuilder
+                ->select($statusField)
+                ->addSelectLiteral(sprintf('COUNT(%s) AS record_count', $queryBuilder->quoteIdentifier('uid')))
+                ->from($table)
+                ->where(
+                    $queryBuilder->expr()->isNotNull($statusField),
+                    $queryBuilder->expr()->neq($statusField, 0),
+                )
+                ->groupBy($statusField)
+                ->executeQuery()
+                ->fetchAllAssociative();
+
+            foreach ($rows as $row) {
+                $statusUid = (int) $row[$statusField];
+                $counts[$statusUid] = ($counts[$statusUid] ?? 0) + (int) $row['record_count'];
+            }
+        }
+
+        return $counts;
+    }
+
+    /**
      * @return array<int, array<string, mixed>>
      *
      * @throws Exception

--- a/Classes/Widgets/Provider/StatusOverviewDataProvider.php
+++ b/Classes/Widgets/Provider/StatusOverviewDataProvider.php
@@ -18,8 +18,6 @@ use TYPO3\CMS\Dashboard\Widgets\ChartDataProviderInterface;
 use Xima\XimaTypo3ContentPlanner\Configuration;
 use Xima\XimaTypo3ContentPlanner\Domain\Repository\{RecordRepository, StatusRepository};
 
-use function count;
-
 /**
  * StatusOverviewDataProvider.
  *
@@ -36,6 +34,9 @@ class StatusOverviewDataProvider implements ChartDataProviderInterface
 
     /** @var string[] */
     protected array $colors = [];
+
+    /** @var array<int, int>|null */
+    private ?array $statusCounts = null;
 
     public function __construct(private readonly StatusRepository $statusRepository, private readonly RecordRepository $recordRepository) {}
 
@@ -60,7 +61,9 @@ class StatusOverviewDataProvider implements ChartDataProviderInterface
 
     public function countPageStatus(?int $status = null): int
     {
-        return count($this->recordRepository->findAllByFilter(status: $status));
+        $this->statusCounts ??= $this->recordRepository->countRecordsByStatus();
+
+        return $this->statusCounts[$status] ?? 0;
     }
 
     protected function calculateStatusCounts(): void

--- a/Tests/Functional/Repository/RecordRepositoryTest.php
+++ b/Tests/Functional/Repository/RecordRepositoryTest.php
@@ -71,6 +71,18 @@ final class RecordRepositoryTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function countRecordsByStatusCountsNonDeletedRecordsPerStatus(): void
+    {
+        $counts = $this->subject->countRecordsByStatus();
+
+        // pages fixture: status 2 (page 1), status 3 (page 2), status 1 (page 3);
+        // page 4 has no status and page 5 (status 2) is deleted, so both are excluded.
+        self::assertSame(1, $counts[1] ?? 0);
+        self::assertSame(1, $counts[2] ?? 0);
+        self::assertSame(1, $counts[3] ?? 0);
+    }
+
+    #[Test]
     public function findByPidReturnsRecordsWithStatusForGivenPid(): void
     {
         $result = $this->subject->findByPid('pages', 1);


### PR DESCRIPTION
## Summary

- \`StatusOverviewDataProvider::countPageStatus\` counted records per status via \`count(findAllByFilter(status: X))\`. That runs a full UNION fetch over all tracked tables per status and, worse, \`findAllByFilter\` caps results at 20 — so the chart silently showed at most 20 per status (a correctness bug), while doing far more work than a count needs.
- Adds \`RecordRepository::countRecordsByStatus()\`, a single aggregated \`COUNT(*) … GROUP BY status\` per tracked table (merged in PHP), and has the provider consume and memoize it. Counts are now accurate and cheap.

## Changes

- \`Classes/Domain/Repository/RecordRepository.php\` - Add \`countRecordsByStatus()\` aggregate
- \`Classes/Widgets/Provider/StatusOverviewDataProvider.php\` - Use the aggregate (memoized) instead of a capped full fetch; drop unused import
- \`Tests/Functional/Repository/RecordRepositoryTest.php\` - Cover per-status counting incl. exclusion of deleted/status-less records