### PR TITLE
perf: batch folder status lookups for subfolders

### DIFF
--- a/Classes/Domain/Repository/FolderStatusRepository.php
+++ b/Classes/Domain/Repository/FolderStatusRepository.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3ContentPlanner\Domain\Repository;
 
-use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\{ArrayParameterType, Exception};
 use InvalidArgumentException;
 use TYPO3\CMS\Core\Database\{Connection, ConnectionPool};
 use TYPO3\CMS\Core\Resource\ResourceFactory;
@@ -70,6 +70,57 @@ class FolderStatusRepository
     }
 
     /**
+     * Batch-resolve folder status rows for several combined identifiers.
+     *
+     * @param array<int, string> $combinedIdentifiers
+     *
+     * @return array<string, array<string, mixed>> map keyed by combined identifier
+     *
+     * @throws Exception
+     */
+    public function findByCombinedIdentifiers(array $combinedIdentifiers): array
+    {
+        // Group requested paths per storage so each storage needs a single IN() query.
+        $pathsByStorage = [];
+        foreach ($combinedIdentifiers as $combinedIdentifier) {
+            $parsed = $this->parseCombinedIdentifier($combinedIdentifier);
+            if (null !== $parsed) {
+                $pathsByStorage[$parsed['storageUid']][$parsed['path']] = $combinedIdentifier;
+            }
+        }
+
+        $result = [];
+        foreach ($pathsByStorage as $storageUid => $pathMap) {
+            $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+            $rows = $queryBuilder
+                ->select('*')
+                ->from(self::TABLE)
+                ->where(
+                    $queryBuilder->expr()->eq(
+                        'storage_uid',
+                        $queryBuilder->createNamedParameter($storageUid, Connection::PARAM_INT),
+                    ),
+                    $queryBuilder->expr()->in(
+                        'folder_identifier',
+                        $queryBuilder->createNamedParameter(array_keys($pathMap), ArrayParameterType::STRING),
+                    ),
+                    $queryBuilder->expr()->eq('deleted', 0),
+                )
+                ->executeQuery()
+                ->fetchAllAssociative();
+
+            foreach ($rows as $row) {
+                $combinedIdentifier = $pathMap[$row['folder_identifier']] ?? null;
+                if (null !== $combinedIdentifier) {
+                    $result[$combinedIdentifier] = $row;
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * Find folder status by its UID.
      *
      * @return array<string, mixed>|false
@@ -111,11 +162,17 @@ class FolderStatusRepository
             return [];
         }
 
+        $identifiers = [];
+        foreach ($subfolders as $subfolder) {
+            $identifiers[] = $subfolder->getStorage()->getUid().':'.$subfolder->getIdentifier();
+        }
+        $statusByIdentifier = $this->findByCombinedIdentifiers($identifiers);
+
         $results = [];
         foreach ($subfolders as $subfolder) {
             $subfolderIdentifier = $subfolder->getStorage()->getUid().':'.$subfolder->getIdentifier();
-            $status = $this->findByCombinedIdentifier($subfolderIdentifier);
-            if ($status && null !== $status[Configuration::FIELD_STATUS] && 0 !== (int) $status[Configuration::FIELD_STATUS]) {
+            $status = $statusByIdentifier[$subfolderIdentifier] ?? null;
+            if (null !== $status && null !== $status[Configuration::FIELD_STATUS] && 0 !== (int) $status[Configuration::FIELD_STATUS]) {
                 $status['combined_identifier'] = $subfolderIdentifier;
                 $status['title'] = $subfolder->getName();
                 $results[] = $status;
@@ -140,14 +197,20 @@ class FolderStatusRepository
             return [];
         }
 
+        $identifiers = [];
+        foreach ($subfolders as $subfolder) {
+            $identifiers[] = $subfolder->getStorage()->getUid().':'.$subfolder->getIdentifier();
+        }
+        $statusByIdentifier = $this->findByCombinedIdentifiers($identifiers);
+
         $results = [];
         foreach ($subfolders as $subfolder) {
             $subfolderIdentifier = $subfolder->getStorage()->getUid().':'.$subfolder->getIdentifier();
-            $status = $this->findByCombinedIdentifier($subfolderIdentifier);
+            $status = $statusByIdentifier[$subfolderIdentifier] ?? null;
             $results[] = [
                 'combined_identifier' => $subfolderIdentifier,
                 'title' => $subfolder->getName(),
-                'status' => $status ?: null,
+                'status' => $status,
             ];
         }
 

--- a/Tests/Functional/Repository/FolderStatusRepositoryTest.php
+++ b/Tests/Functional/Repository/FolderStatusRepositoryTest.php
@@ -64,6 +64,30 @@ final class FolderStatusRepositoryTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function findByCombinedIdentifiersBatchResolvesMultipleFolders(): void
+    {
+        $result = $this->subject->findByCombinedIdentifiers([
+            '1:/user_upload/',
+            '1:/user_upload/sub/',
+            '1:/deleted_folder/',
+            '1:/nonexistent/',
+        ]);
+
+        self::assertArrayHasKey('1:/user_upload/', $result);
+        self::assertArrayHasKey('1:/user_upload/sub/', $result);
+        self::assertArrayNotHasKey('1:/deleted_folder/', $result);
+        self::assertArrayNotHasKey('1:/nonexistent/', $result);
+        self::assertSame(2, (int) $result['1:/user_upload/']['tx_ximatypo3contentplanner_status']);
+        self::assertSame(3, (int) $result['1:/user_upload/sub/']['tx_ximatypo3contentplanner_status']);
+    }
+
+    #[Test]
+    public function findByCombinedIdentifiersReturnsEmptyArrayForNoInput(): void
+    {
+        self::assertSame([], $this->subject->findByCombinedIdentifiers([]));
+    }
+
+    #[Test]
     public function findByUidReturnsMatchingRecord(): void
     {
         $result = $this->subject->findByUid(2);


### PR DESCRIPTION
## Summary

- \`findSubfoldersWithStatus\` and \`getAllSubfolders\` called \`findByCombinedIdentifier\` once per subfolder, producing one query per subfolder (50–200 round-trips for large media folders on every file list render).
- Adds \`findByCombinedIdentifiers()\`, which resolves all requested folders with a single \`folder_identifier IN (...)\` query per storage, and rewires both methods to use it.

## Changes

- \`Classes/Domain/Repository/FolderStatusRepository.php\` - Add batch lookup and use it in both subfolder methods
- \`Tests/Functional/Repository/FolderStatusRepositoryTest.php\` - Cover batch resolution, deleted/unknown exclusion, and empty input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved folder status retrieval to handle multiple folder identifiers in a single batch lookup.
  * Folder listings now return status information more consistently across subfolders.

* **Bug Fixes**
  * Reduced missed or inconsistent folder status results when browsing subfolders.
  * Empty requests now safely return an empty result set.

* **Tests**
  * Added functional coverage for batch folder status resolution, including mixed results and empty input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->