### PR TITLE
perf: use UNION ALL for filter query to skip redundant de-duplication

### DIFF
--- a/Classes/Domain/Repository/RecordRepository.php
+++ b/Classes/Domain/Repository/RecordRepository.php
@@ -62,7 +62,9 @@ class RecordRepository
         $this->applyFilterConditions($baseWhere, $additionalParams, $search, $status, $assignee);
 
         $sqlArray = $this->buildUnionQueriesForTables($baseWhere, $type, $todo, $search, $openComments);
-        $sql = implode(' UNION ', $sqlArray).' ORDER BY tstamp DESC LIMIT :limit';
+        // UNION ALL avoids an unnecessary de-duplication pass: each sub-query carries a distinct
+        // tablename literal, so cross-table duplicates cannot occur.
+        $sql = implode(' UNION ALL ', $sqlArray).' ORDER BY tstamp DESC LIMIT :limit';
 
         $statement = $queryBuilder->getConnection()->executeQuery($sql, $additionalParams);
         $results = $statement->fetchAllAssociative();


### PR DESCRIPTION
## Summary

- \`RecordRepository::findAllByFilter\` combined its per-table sub-queries with \`UNION\`, which forces the database to run a de-duplication pass (temp table / sort). Each sub-query selects a distinct \`tablename\` literal and uids are unique per table, so no cross-table duplicates can exist and the pass is pure overhead.
- Switches to \`UNION ALL\`, which returns identical results without the de-duplication step.

## Testing

\`findAllByFilter\` builds raw \`(SELECT …) UNION …\` SQL that the SQLite functional-test driver cannot execute (see the existing note in \`RecordRepositoryTest\`), so this query is not covered by an automated test. The change is a semantics-preserving swap; the unit suite and the rest of the functional suite remain green, and full-project PHPStan passes.

## Changes

- \`Classes/Domain/Repository/RecordRepository.php\` - Combine filter sub-queries with \`UNION ALL\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved retrieval performance when filtering records across multiple tables by eliminating unnecessary duplicate-removal processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->