### PR TITLE
perf: process comment datamap only while handling the comment record

### DIFF
--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -60,10 +60,13 @@ final readonly class DataHandlerHook // @phpstan-ignore-line complexity.classLik
     {
         // Only process comments while the comment record itself is being handled — the hook fires
         // once per datamap record, so guarding on the datamap alone re-ran this for every record.
+        // Must run before the integer-id early return below: a newly created comment has a "NEW..."
+        // id, which fixNewCommentEntry() specifically needs to resolve.
         if (Configuration::TABLE_COMMENT === $table) {
             $this->updateCommentTodo($dataHandler);
             $this->checkCommentResolved($dataHandler);
             $this->checkCommentEdited($dataHandler);
+            $this->fixNewCommentEntry($dataHandler);
         }
 
         if (!MathUtility::canBeInterpretedAsInteger($id)) {
@@ -72,10 +75,6 @@ final readonly class DataHandlerHook // @phpstan-ignore-line complexity.classLik
 
         if (ExtensionUtility::isRegisteredRecordTable($table)) {
             $this->statusChangeManager->processContentPlannerFields($incomingFieldArray, $table, (int) $id);
-        }
-
-        if (Configuration::TABLE_COMMENT === $table) {
-            $this->fixNewCommentEntry($dataHandler);
         }
     }
 

--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -58,7 +58,9 @@ final readonly class DataHandlerHook // @phpstan-ignore-line complexity.classLik
      */
     public function processDatamap_preProcessFieldArray(array &$incomingFieldArray, $table, $id, DataHandler $dataHandler): void
     {
-        if (array_key_exists(Configuration::TABLE_COMMENT, $dataHandler->datamap)) {
+        // Only process comments while the comment record itself is being handled — the hook fires
+        // once per datamap record, so guarding on the datamap alone re-ran this for every record.
+        if (Configuration::TABLE_COMMENT === $table) {
             $this->updateCommentTodo($dataHandler);
             $this->checkCommentResolved($dataHandler);
             $this->checkCommentEdited($dataHandler);
@@ -72,7 +74,7 @@ final readonly class DataHandlerHook // @phpstan-ignore-line complexity.classLik
             $this->statusChangeManager->processContentPlannerFields($incomingFieldArray, $table, (int) $id);
         }
 
-        if (array_key_exists(Configuration::TABLE_COMMENT, $dataHandler->datamap)) {
+        if (Configuration::TABLE_COMMENT === $table) {
             $this->fixNewCommentEntry($dataHandler);
         }
     }

--- a/Tests/Functional/Hooks/DataHandlerHookTest.php
+++ b/Tests/Functional/Hooks/DataHandlerHookTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Tests\Functional\Hooks;
+
+use PHPUnit\Framework\Attributes\Test;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Xima\XimaTypo3ContentPlanner\Configuration;
+use Xima\XimaTypo3ContentPlanner\Domain\Repository\{CommentRepository, RecordRepository};
+use Xima\XimaTypo3ContentPlanner\Hooks\DataHandlerHook;
+use Xima\XimaTypo3ContentPlanner\Manager\StatusChangeManager;
+use Xima\XimaTypo3ContentPlanner\Tests\Functional\AbstractFunctionalTestCase;
+
+/**
+ * DataHandlerHookTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class DataHandlerHookTest extends AbstractFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->loginBackendUser();
+    }
+
+    #[Test]
+    public function preProcessProcessesCommentTodosOnlyWhenHandlingTheCommentRecord(): void
+    {
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->datamap = [
+            Configuration::TABLE_COMMENT => [
+                'NEW123' => ['content' => '<input type="checkbox" checked><input type="checkbox">'],
+            ],
+        ];
+        $hook = $this->createHook();
+        $fields = [];
+
+        // Handling an unrelated record (a page) must not touch the comment datamap.
+        $hook->processDatamap_preProcessFieldArray($fields, 'pages', 1, $dataHandler);
+        self::assertArrayNotHasKey('todo_total', $dataHandler->datamap[Configuration::TABLE_COMMENT]['NEW123']);
+
+        // Handling the comment record processes its to-dos exactly once.
+        $hook->processDatamap_preProcessFieldArray($fields, Configuration::TABLE_COMMENT, 'NEW123', $dataHandler);
+        self::assertSame(2, $dataHandler->datamap[Configuration::TABLE_COMMENT]['NEW123']['todo_total']);
+        self::assertSame(1, $dataHandler->datamap[Configuration::TABLE_COMMENT]['NEW123']['todo_resolved']);
+    }
+
+    private function createHook(): DataHandlerHook
+    {
+        return new DataHandlerHook(
+            $this->createMock(FrontendInterface::class),
+            $this->get(StatusChangeManager::class),
+            $this->get(RecordRepository::class),
+            $this->get(CommentRepository::class),
+            $this->get(EventDispatcherInterface::class),
+        );
+    }
+}

--- a/Tests/Functional/Hooks/DataHandlerHookTest.php
+++ b/Tests/Functional/Hooks/DataHandlerHookTest.php
@@ -60,6 +60,29 @@ final class DataHandlerHookTest extends AbstractFunctionalTestCase
         self::assertSame(1, $dataHandler->datamap[Configuration::TABLE_COMMENT]['NEW123']['todo_resolved']);
     }
 
+    #[Test]
+    public function preProcessResolvesNewCommentEntryEvenWhenCommentIsNotTheFirstDatamapTable(): void
+    {
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        // A mixed save (e.g. page + comment created together) where the comment table is
+        // not the first key — processDatamap_beforeStart() would skip it in this case.
+        $dataHandler->datamap = [
+            'pages' => [1 => ['title' => 'Test']],
+            Configuration::TABLE_COMMENT => [
+                'NEW456' => ['content' => 'a new comment'],
+            ],
+        ];
+        $hook = $this->createHook();
+        $fields = [];
+
+        $hook->processDatamap_preProcessFieldArray($fields, 'pages', 1, $dataHandler);
+        // fixNewCommentEntry() must still run once the comment record itself is handled,
+        // resolving its "NEW..." id despite the non-integer id early return further down.
+        $hook->processDatamap_preProcessFieldArray($fields, Configuration::TABLE_COMMENT, 'NEW456', $dataHandler);
+
+        self::assertArrayHasKey('author', $dataHandler->datamap[Configuration::TABLE_COMMENT]['NEW456']);
+    }
+
     private function createHook(): DataHandlerHook
     {
         return new DataHandlerHook(


### PR DESCRIPTION
## Summary

- \`processDatamap_preProcessFieldArray\` runs once per datamap record, but it guarded the comment processing (\`updateCommentTodo\`, \`checkCommentResolved\`, \`checkCommentEdited\`, \`fixNewCommentEntry\`) on \`array_key_exists(TABLE_COMMENT, datamap)\`. Since those methods each iterate the whole comment datamap, a save with a comment plus N other records re-ran all of it N+1 times — including a \`DOMDocument::loadHTML\` per comment and a \`findByUid\` query per edited comment.
- Guards the comment processing on \`TABLE_COMMENT === $table\` instead, so it runs only while the comment record itself is being handled. Comment saving is unaffected (the comment record is always processed, and \`processDatamap_beforeStart\` still covers the comment-first case).

## Changes

- \`Classes/Hooks/DataHandlerHook.php\` - Guard comment processing on the current record's table
- \`Tests/Functional/Hooks/DataHandlerHookTest.php\` - Assert comment to-dos are processed only when the comment record is handled, not for unrelated records

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Comment-related updates are now applied only when editing the actual comment entry, preventing repeated processing across other records.
  * Newly created comments are resolved correctly even when the comment record is not processed first.
  * Comment totals and resolution status are calculated once per relevant edit, improving consistency.

* **Tests**
  * Added functional coverage for comment-only processing and correct handling of newly created comments in different processing orders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->