### PR TITLE
perf: load status item todo totals with a single combined query

### DIFF
--- a/Classes/Domain/Model/Dto/StatusItem.php
+++ b/Classes/Domain/Model/Dto/StatusItem.php
@@ -186,11 +186,9 @@ final class StatusItem
             return 0;
         }
 
-        if (null === $this->cachedToDoResolved) {
-            $this->cachedToDoResolved = PlannerUtility::hasComments($this->data) ? $this->getCommentRepository()->countTodoAllByRecord((int) $this->data['uid'], $this->data['tablename']) : 0;
-        }
+        $this->loadTodoCounts();
 
-        return $this->cachedToDoResolved;
+        return $this->cachedToDoResolved ?? 0;
     }
 
     public function getToDoTotal(): int
@@ -199,11 +197,9 @@ final class StatusItem
             return 0;
         }
 
-        if (null === $this->cachedToDoTotal) {
-            $this->cachedToDoTotal = PlannerUtility::hasComments($this->data) ? $this->getCommentRepository()->countTodoAllByRecord((int) $this->data['uid'], $this->data['tablename'], 'todo_total') : 0;
-        }
+        $this->loadTodoCounts();
 
-        return $this->cachedToDoTotal;
+        return $this->cachedToDoTotal ?? 0;
     }
 
     /**
@@ -229,6 +225,27 @@ final class StatusItem
             'todoShareUrl' => $this->getToDoShareUrl(),
             'site' => $this->getSite(),
         ];
+    }
+
+    /**
+     * Load total and resolved to-do sums in a single query (memoized per item).
+     */
+    private function loadTodoCounts(): void
+    {
+        if (null !== $this->cachedToDoTotal) {
+            return;
+        }
+
+        if (!PlannerUtility::hasComments($this->data)) {
+            $this->cachedToDoTotal = 0;
+            $this->cachedToDoResolved = 0;
+
+            return;
+        }
+
+        $counts = $this->getCommentRepository()->countTodosByRecord((int) $this->data['uid'], $this->data['tablename']);
+        $this->cachedToDoTotal = $counts['total'];
+        $this->cachedToDoResolved = $counts['resolved'];
     }
 
     /**

--- a/Classes/Domain/Repository/CommentRepository.php
+++ b/Classes/Domain/Repository/CommentRepository.php
@@ -166,6 +166,37 @@ class CommentRepository
     }
 
     /**
+     * Sum total and resolved to-dos of a record's open comments in a single query.
+     *
+     * @return array{total: int, resolved: int}
+     *
+     * @throws Exception
+     */
+    public function countTodosByRecord(int $id, string $table): array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $row = $queryBuilder
+            ->selectLiteral(
+                'COALESCE(SUM(`todo_total`), 0) AS `total`',
+                'COALESCE(SUM(`todo_resolved`), 0) AS `resolved`',
+            )
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->eq('foreign_uid', $queryBuilder->createNamedParameter($id, Connection::PARAM_INT)),
+                $queryBuilder->expr()->eq('foreign_table', $queryBuilder->createNamedParameter($table, Connection::PARAM_STR)),
+                $queryBuilder->expr()->eq('deleted', 0),
+                $queryBuilder->expr()->eq('resolved_date', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+            )
+            ->executeQuery()
+            ->fetchAssociative();
+
+        return [
+            'total' => (int) ($row['total'] ?? 0),
+            'resolved' => (int) ($row['resolved'] ?? 0),
+        ];
+    }
+
+    /**
      * Find the UID of the comment with todos for a record - only if exactly one such comment exists.
      * Returns null when multiple comments have todos (caller should fall back to the comments modal).
      */

--- a/Tests/Functional/Repository/CommentRepositoryTest.php
+++ b/Tests/Functional/Repository/CommentRepositoryTest.php
@@ -143,6 +143,15 @@ final class CommentRepositoryTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function countTodosByRecordReturnsTotalAndResolvedInOneCall(): void
+    {
+        self::assertSame(
+            ['total' => 3, 'resolved' => 1],
+            $this->subject->countTodosByRecord(10, 'pages'),
+        );
+    }
+
+    #[Test]
     public function countTodoAllByRecordThrowsForInvalidField(): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
## Summary

- \`StatusItem::getToDoTotal()\` and \`getToDoResolved()\` each issued their own \`SUM(...)\` query against the comment table with an identical WHERE clause, so every rendered item with comments cost two queries (and \`getToDoHtml\` calls both getters repeatedly).
- Adds \`CommentRepository::countTodosByRecord()\` which returns both sums in one query, and has \`StatusItem\` load them once via a shared memoized \`loadTodoCounts()\`. Return values are unchanged.

Combined with the status and backend-user memoization PRs, this removes the duplicate per-item to-do queries. (Cross-item batching would additionally require threading pre-computed counts through \`StatusItem::create()\`, which is left as a follow-up.)

## Changes

- \`Classes/Domain/Repository/CommentRepository.php\` - Add \`countTodosByRecord()\` returning total and resolved in one query
- \`Classes/Domain/Model/Dto/StatusItem.php\` - Load both to-do sums once via \`loadTodoCounts()\`
- \`Tests/Functional/Repository/CommentRepositoryTest.php\` - Cover the combined count