### PR TITLE
perf: reuse loaded record in record list status dropdown

### DIFF
--- a/Classes/EventListener/ModifyRecordListRecordActionsListener.php
+++ b/Classes/EventListener/ModifyRecordListRecordActionsListener.php
@@ -93,7 +93,8 @@ final readonly class ModifyRecordListRecordActionsListener
             ->setTitle($title)
             ->setIcon($this->iconFactory->getIcon($icon, IconSize::SMALL));
 
-        $actionsToAdd = $this->dropDownSelectionService->generateSelection($table, $uid);
+        // Reuse the record already loaded above instead of a second lookup inside generateSelection().
+        $actionsToAdd = $this->dropDownSelectionService->generateSelection($table, $uid, $record);
         if (!is_array($actionsToAdd)) {
             return;
         }

--- a/Classes/Service/SelectionBuilder/AbstractSelectionService.php
+++ b/Classes/Service/SelectionBuilder/AbstractSelectionService.php
@@ -46,11 +46,13 @@ class AbstractSelectionService
     ) {}
 
     /**
+     * @param array<string, mixed>|bool|null $record pre-loaded record to reuse instead of a fresh lookup
+     *
      * @return array<string, mixed>|bool
      *
      * @throws NotImplementedException|Exception
      */
-    public function generateSelection(string $table, int $uid): array|bool
+    public function generateSelection(string $table, int $uid, array|bool|null $record = null): array|bool
     {
         if (!$this->shouldGenerateSelection($table)) {
             return false;
@@ -61,7 +63,9 @@ class AbstractSelectionService
             return false;
         }
 
-        $record = $this->getCurrentRecord($table, $uid);
+        if (!is_array($record)) {
+            $record = $this->getCurrentRecord($table, $uid);
+        }
         $selectionEntriesToAdd = [];
 
         $this->addHeaderItemToSelection($selectionEntriesToAdd);

--- a/Tests/Functional/Service/SelectionBuilder/DropDownSelectionServiceTest.php
+++ b/Tests/Functional/Service/SelectionBuilder/DropDownSelectionServiceTest.php
@@ -15,6 +15,7 @@ namespace Xima\XimaTypo3ContentPlanner\Tests\Functional\Service\SelectionBuilder
 
 use PHPUnit\Framework\Attributes\Test;
 use Xima\XimaTypo3ContentPlanner\Configuration;
+use Xima\XimaTypo3ContentPlanner\Domain\Repository\RecordRepository;
 use Xima\XimaTypo3ContentPlanner\Service\SelectionBuilder\DropDownSelectionService;
 use Xima\XimaTypo3ContentPlanner\Tests\Functional\AbstractFunctionalTestCase;
 
@@ -50,6 +51,19 @@ final class DropDownSelectionServiceTest extends AbstractFunctionalTestCase
         self::assertArrayHasKey('reset', $result);
         self::assertArrayHasKey('assignee', $result);
         self::assertArrayHasKey('comments', $result);
+    }
+
+    #[Test]
+    public function generateSelectionReusesPreloadedRecord(): void
+    {
+        $record = $this->get(RecordRepository::class)->findByUid('pages', 1, true);
+
+        $withPreloadedRecord = $this->subject->generateSelection('pages', 1, $record);
+        $withInternalLookup = $this->subject->generateSelection('pages', 1);
+
+        self::assertIsArray($withPreloadedRecord);
+        self::assertIsArray($withInternalLookup);
+        self::assertSame(array_keys($withInternalLookup), array_keys($withPreloadedRecord));
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- \`ModifyRecordListRecordActionsListener\` (fired once per record list row) loaded the record via \`RecordRepository::findByUid\`, then called \`generateSelection()\`, which loaded the exact same record again through \`getCurrentRecord()\` — a duplicate lookup per row.
- \`generateSelection()\` now accepts an optional pre-loaded record and only falls back to a lookup when none is passed. The listener passes the record it already has. Other callers are unaffected (the parameter is optional).

Related per-row costs are reduced by the status-repository memoization and combined to-do count PRs.

## Changes

- \`Classes/Service/SelectionBuilder/AbstractSelectionService.php\` - Accept an optional pre-loaded record in \`generateSelection()\`
- \`Classes/EventListener/ModifyRecordListRecordActionsListener.php\` - Pass the already-loaded record
- \`Tests/Functional/Service/SelectionBuilder/DropDownSelectionServiceTest.php\` - Assert a pre-loaded record yields the same selection as an internal lookup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown action generation by reusing already-loaded record data.
  * Reduced unnecessary record lookups while preserving existing selection results.

* **Tests**
  * Added coverage confirming that preloaded and freshly retrieved records produce identical dropdown actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->