### PR TITLE
perf: batch file metadata lookups for the file list

### DIFF
--- a/Classes/Domain/Repository/SysFileMetadataRepository.php
+++ b/Classes/Domain/Repository/SysFileMetadataRepository.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3ContentPlanner\Domain\Repository;
 
-use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\{ArrayParameterType, Exception};
 use TYPO3\CMS\Core\Database\{Connection, ConnectionPool};
 use TYPO3\CMS\Core\Resource\{File, ResourceFactory};
 use Xima\XimaTypo3ContentPlanner\Configuration;
+
+use function array_map;
 
 /**
  * SysFileMetadataRepository.
@@ -147,6 +149,56 @@ class SysFileMetadataRepository
     }
 
     /**
+     * Batch-resolve metadata records for several file identifiers.
+     *
+     * @param array<int, string> $identifiers
+     *
+     * @return array<string, array<string, mixed>> keyed by file identifier
+     *
+     * @throws Exception
+     */
+    public function findByIdentifiers(array $identifiers): array
+    {
+        if ([] === $identifiers) {
+            return [];
+        }
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $rows = $queryBuilder
+            ->select(
+                'sys_file_metadata.uid',
+                'sys_file.name as title',
+                'sys_file.identifier',
+                'sys_file.uid as file_uid',
+                'sys_file_metadata.'.Configuration::FIELD_STATUS,
+                'sys_file_metadata.'.Configuration::FIELD_ASSIGNEE,
+                'sys_file_metadata.'.Configuration::FIELD_COMMENTS,
+            )
+            ->from(self::TABLE)
+            ->innerJoin(
+                'sys_file_metadata',
+                'sys_file',
+                'sys_file',
+                'sys_file_metadata.file = sys_file.uid',
+            )
+            ->where(
+                $queryBuilder->expr()->in(
+                    'sys_file.identifier',
+                    $queryBuilder->createNamedParameter($identifiers, ArrayParameterType::STRING),
+                ),
+            )
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $byIdentifier = [];
+        foreach ($rows as $row) {
+            $byIdentifier[(string) $row['identifier']] = $row;
+        }
+
+        return $byIdentifier;
+    }
+
+    /**
      * Get all files in a folder using ResourceFactory.
      *
      * @return File[]
@@ -173,11 +225,13 @@ class SysFileMetadataRepository
     public function findByFolderWithStatus(string $combinedIdentifier): array
     {
         $files = $this->findFilesByFolder($combinedIdentifier);
-        $results = [];
+        $identifiers = array_map(static fn (File $file): string => $file->getIdentifier(), $files);
+        $metadataByIdentifier = $this->findByIdentifiers($identifiers);
 
+        $results = [];
         foreach ($files as $file) {
-            $metadata = $this->findByIdentifier($file->getIdentifier());
-            if ($metadata && null !== $metadata[Configuration::FIELD_STATUS] && 0 !== (int) $metadata[Configuration::FIELD_STATUS]) {
+            $metadata = $metadataByIdentifier[$file->getIdentifier()] ?? null;
+            if (null !== $metadata && null !== $metadata[Configuration::FIELD_STATUS] && 0 !== (int) $metadata[Configuration::FIELD_STATUS]) {
                 $results[] = $metadata;
             }
         }

--- a/Classes/Service/FileList/FileListStatusService.php
+++ b/Classes/Service/FileList/FileListStatusService.php
@@ -52,13 +52,8 @@ class FileListStatusService
      */
     private function addFileStatusStyles(array &$css, string $folderIdentifier, bool $isTilesView): void
     {
-        $files = $this->sysFileMetadataRepository->findFilesByFolder($folderIdentifier);
-        foreach ($files as $file) {
-            $metadata = $this->sysFileMetadataRepository->findByIdentifier($file->getIdentifier());
-            if (!$this->hasValidStatus($metadata)) {
-                continue;
-            }
-
+        // findByFolderWithStatus() already batches the metadata lookup and filters to files with a status.
+        foreach ($this->sysFileMetadataRepository->findByFolderWithStatus($folderIdentifier) as $metadata) {
             $status = $this->statusRepository->findByUid((int) $metadata[Configuration::FIELD_STATUS]);
             if (!$status instanceof Status) {
                 continue;
@@ -84,16 +79,6 @@ class FileListStatusService
 
             $css[] = $this->buildFolderCssRule($subfolder['combined_identifier'], $status, $isTilesView);
         }
-    }
-
-    /**
-     * @param array<string, mixed>|false $metadata
-     */
-    private function hasValidStatus(array|false $metadata): bool
-    {
-        return $metadata
-            && null !== $metadata[Configuration::FIELD_STATUS]
-            && 0 !== (int) $metadata[Configuration::FIELD_STATUS];
     }
 
     private function buildFileCssRule(int $metaUid, Status $status, bool $isTilesView): string

--- a/Tests/Functional/Repository/SysFileMetadataRepositoryTest.php
+++ b/Tests/Functional/Repository/SysFileMetadataRepositoryTest.php
@@ -84,6 +84,28 @@ final class SysFileMetadataRepositoryTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function findByIdentifiersBatchResolvesMultipleFiles(): void
+    {
+        $result = $this->subject->findByIdentifiers([
+            '/user_upload/example.pdf',
+            '/user_upload/image.jpg',
+            '/user_upload/ghost.txt',
+        ]);
+
+        self::assertArrayHasKey('/user_upload/example.pdf', $result);
+        self::assertArrayHasKey('/user_upload/image.jpg', $result);
+        self::assertArrayNotHasKey('/user_upload/ghost.txt', $result);
+        self::assertSame(1, (int) $result['/user_upload/example.pdf']['uid']);
+        self::assertSame(2, (int) $result['/user_upload/example.pdf']['tx_ximatypo3contentplanner_status']);
+    }
+
+    #[Test]
+    public function findByIdentifiersReturnsEmptyArrayForNoInput(): void
+    {
+        self::assertSame([], $this->subject->findByIdentifiers([]));
+    }
+
+    #[Test]
     public function updateStatusChangesStatusOnly(): void
     {
         $this->subject->updateStatus(2, 3);


### PR DESCRIPTION
## Summary

- Rendering the file list resolved status metadata with one \`findByIdentifier\` query per file (\`FileListStatusService::addFileStatusStyles\` and \`SysFileMetadataRepository::findByFolderWithStatus\`), i.e. N+1 queries for a folder with N files on every file list render.
- Adds \`SysFileMetadataRepository::findByIdentifiers()\`, which resolves all files in one \`sys_file.identifier IN (...)\` query keyed by identifier. \`findByFolderWithStatus\` now uses it, and \`FileListStatusService\` reuses \`findByFolderWithStatus\` (dropping its own per-file loop and the now-redundant \`hasValidStatus\` helper).

The \`FileListModifier\` render path still resolves per file and could reuse the same batch in a follow-up.

## Changes

- \`Classes/Domain/Repository/SysFileMetadataRepository.php\` - Add \`findByIdentifiers()\` batch and use it in \`findByFolderWithStatus\`
- \`Classes/Service/FileList/FileListStatusService.php\` - Reuse the batched \`findByFolderWithStatus\`; remove the obsolete helper
- \`Tests/Functional/Repository/SysFileMetadataRepositoryTest.php\` - Cover batch resolution, unknown-identifier exclusion, and empty input