### PR TITLE
fix: give tree status labels an explicit priority (#287)

### DIFF
--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -43,6 +43,16 @@ class Configuration
 
     final public const CACHE_IDENTIFIER = 'ximatypo3contentplanner';
 
+    /*
+     * The page and file tree paint only the highest-priority label per node. The status
+     * label therefore has to outrank the labels core appends before our event listeners
+     * run: the TSconfig label (priority 0) and the background color label (priority -1).
+     * The empty label, which only exists to stop labels from being inherited by child
+     * nodes, has to stay below both so it never suppresses them.
+     */
+    final public const TREE_LABEL_PRIORITY_STATUS = 100;
+    final public const TREE_LABEL_PRIORITY_EMPTY = -2;
+
     final public const TABLE_FOLDER = 'tx_ximatypo3contentplanner_folder';
     final public const TABLE_COMMENT = 'tx_ximatypo3contentplanner_comment';
     final public const TABLE_STATUS = 'tx_ximatypo3contentplanner_status';

--- a/Classes/EventListener/AfterFileStorageTreeItemsPreparedListener.php
+++ b/Classes/EventListener/AfterFileStorageTreeItemsPreparedListener.php
@@ -93,6 +93,7 @@ final readonly class AfterFileStorageTreeItemsPreparedListener
         $item['labels'][] = new \TYPO3\CMS\Backend\Dto\Tree\Label\Label(
             label: $status->getTitle(),
             color: Configuration\Colors::get($status->getColor()),
+            priority: Configuration::TREE_LABEL_PRIORITY_STATUS,
         );
     }
 
@@ -106,6 +107,7 @@ final readonly class AfterFileStorageTreeItemsPreparedListener
         $item['labels'][] = new \TYPO3\CMS\Backend\Dto\Tree\Label\Label(
             label: '',
             color: 'inherit',
+            priority: Configuration::TREE_LABEL_PRIORITY_EMPTY,
         );
     }
 }

--- a/Classes/EventListener/AfterPageTreeItemsPreparedListener.php
+++ b/Classes/EventListener/AfterPageTreeItemsPreparedListener.php
@@ -70,6 +70,7 @@ final readonly class AfterPageTreeItemsPreparedListener
         $item['labels'][] = new \TYPO3\CMS\Backend\Dto\Tree\Label\Label(
             label: $status->getTitle(),
             color: Configuration\Colors::get($status->getColor()),
+            priority: Configuration::TREE_LABEL_PRIORITY_STATUS,
         );
         $this->addStatusInformationIfEnabled($item);
     }
@@ -145,6 +146,7 @@ final readonly class AfterPageTreeItemsPreparedListener
         $item['labels'][] = new \TYPO3\CMS\Backend\Dto\Tree\Label\Label(
             label: '',
             color: 'inherit',
+            priority: Configuration::TREE_LABEL_PRIORITY_EMPTY,
         );
     }
 }

--- a/Tests/Functional/EventListener/AfterPageTreeItemsPreparedListenerTest.php
+++ b/Tests/Functional/EventListener/AfterPageTreeItemsPreparedListenerTest.php
@@ -72,6 +72,46 @@ final class AfterPageTreeItemsPreparedListenerTest extends AbstractFunctionalTes
     }
 
     #[Test]
+    public function statusLabelOutranksLabelsFromOtherSources(): void
+    {
+        // The tree renders only the highest-priority label per node. Core appends the
+        // TSconfig label (priority 0) and the background color label (priority -1)
+        // before this event is dispatched, so both already sit in front of ours.
+        $event = $this->createEvent([
+            [
+                '_page' => ['uid' => 1, Configuration::FIELD_STATUS => 1, Configuration::FIELD_COMMENTS => 0],
+                'labels' => [
+                    new Label(label: 'Color: #00ff00', color: '#00ff00', priority: -1),
+                    new Label(label: 'TSconfig', color: '#ff0000'),
+                ],
+            ],
+        ]);
+
+        $this->subject->__invoke($event);
+
+        $items = $event->getItems();
+        self::assertSame('Draft', $this->winningLabel($items[0]['labels'])->label);
+    }
+
+    #[Test]
+    public function emptyLabelWorkaroundDoesNotOutrankLabelsFromOtherSources(): void
+    {
+        $event = $this->createEvent([
+            [
+                '_page' => ['uid' => 2, Configuration::FIELD_STATUS => 0],
+                'labels' => [
+                    new Label(label: 'Color: #00ff00', color: '#00ff00', priority: -1),
+                ],
+            ],
+        ]);
+
+        $this->subject->__invoke($event);
+
+        $items = $event->getItems();
+        self::assertSame('Color: #00ff00', $this->winningLabel($items[0]['labels'])->label);
+    }
+
+    #[Test]
     public function ignoresUnknownStatusUid(): void
     {
         $event = $this->createEvent([
@@ -109,6 +149,21 @@ final class AfterPageTreeItemsPreparedListenerTest extends AbstractFunctionalTes
 
         $items = $event->getItems();
         self::assertSame('', $items[0]['labels'][0]->label);
+    }
+
+    /**
+     * Mirrors the core tree rendering, which sorts labels by priority descending
+     * (stable) and paints only the first one.
+     *
+     * @see typo3/cms-backend/Resources/Public/JavaScript/tree/tree.js getNodeLabels()
+     *
+     * @param array<int, Label> $labels
+     */
+    private function winningLabel(array $labels): Label
+    {
+        usort($labels, static fn (Label $a, Label $b): int => $b->priority - $a->priority);
+
+        return $labels[0];
     }
 
     /**


### PR DESCRIPTION
Fixes #287.

## Problem

The page tree paints **only one** label per node: `getNodeLabels()` sorts `$item['labels']` by `priority` descending and `createNodeLabel()` uses `t[0]`. Everything else lands in the tooltip only.

Core appends its labels *before* `AfterPageTreeItemsPreparedEvent` is dispatched:

| Source | Priority |
|---|---|
| `TreeController:387` background colour label | `-1` |
| `TreeController:391` TSconfig label (`options.pageTree.label.<pid>`) | `0` (default) |
| CP status label | `0` (default) |

`Array.prototype.sort` is stable and the comparator returns `0` for equal priorities, so the TSconfig label kept index 0 and the status colour was silently dropped.

## Also fixed

`applyEmptyLabelWorkaround()` — the empty `inherit` label that stops labels being inherited by child nodes — used the default priority `0` too, and therefore **outranked core's background colour label (`-1`)** on nodes *without* a CP status. Same root cause, opposite direction; a page with a TSconfig `backgroundColor` and no status lost its colour.

## Change

Two explicit priorities in `Configuration`, applied in both the page tree and the file storage tree listener:

- `TREE_LABEL_PRIORITY_STATUS = 100` — the status label outranks TSconfig labels and anything else appended at the default priority
- `TREE_LABEL_PRIORITY_EMPTY = -2` — the inheritance blocker stays below both core labels, so it never suppresses them

Precedence is now a deliberate choice rather than a side effect of insertion order. `priority` exists on the `Label` DTO in both 13.4.32 and 14.3.4, so the change is version-neutral. Not made configurable (YAGNI) — it can be added later without a breaking change.

## Test plan

- [x] Two new functional tests in `AfterPageTreeItemsPreparedListenerTest`, both RED before the fix, covering each direction. A `winningLabel()` helper mirrors core's stable descending sort so the assertions test what the tree actually paints, not just array order.
- [x] Full suite: 345 tests, 569 assertions, 0 failures (3 pre-existing v14-only skips)
- [x] PHPStan level 6: no errors
- [x] `php-cs-fixer` clean on all changed files
- [ ] Manual check in the v13 and v14 backend with `options.pageTree.label.<uid>` set on a page that also carries a status

## Note

`statusInformation` has the same single-slot behaviour (`createNodeStatusInformation`), as the issue mentions. Left untouched here — CP is currently the only source appending to it, so there is no collision to fix yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved label ordering in page and file-storage trees.
  - Status labels now take precedence when multiple labels are available.
  - Empty-label placeholders no longer override meaningful labels from other sources.
  - Tree labels now appear in a more consistent and predictable order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->