### PR TITLE
chore: drop doc block comments rejected by the header fixer

### DIFF
--- a/Tests/Functional/Controller/FolderControllerTest.php
+++ b/Tests/Functional/Controller/FolderControllerTest.php
@@ -24,9 +24,6 @@ use Xima\XimaTypo3ContentPlanner\Tests\Functional\AbstractFunctionalTestCase;
 /**
  * FolderControllerTest.
  *
- * Redirect handling relies on GeneralUtility::sanitizeLocalUrl(), which needs an initialized
- * Environment — only available in the functional bootstrap, hence these cases live here.
- *
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */

--- a/Tests/Functional/Controller/ProxyControllerTest.php
+++ b/Tests/Functional/Controller/ProxyControllerTest.php
@@ -22,9 +22,6 @@ use Xima\XimaTypo3ContentPlanner\Tests\Functional\AbstractFunctionalTestCase;
 /**
  * ProxyControllerTest.
  *
- * The redirect validation uses GeneralUtility::sanitizeLocalUrl(), which needs an initialized
- * Environment — only available in the functional bootstrap, hence this case lives here.
- *
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-2.0-or-later
  */


### PR DESCRIPTION
`ddev cgl lint` currently fails on `main` with exit code 8 — `php-doc-block-header-fixer` wants the free-text paragraphs removed from the class doc blocks of two functional test cases:

- `Tests/Functional/Controller/FolderControllerTest.php`
- `Tests/Functional/Controller/ProxyControllerTest.php`

This applies the fixer's own output so lint is green again. Both files are otherwise untouched; the removed text only explained why those cases live in the functional suite rather than the unit suite (`GeneralUtility::sanitizeLocalUrl()` needs an initialized `Environment`).

## Test plan

- [x] `ddev cgl lint:php` → `Found 0 of 173 files that can be fixed`
- [x] No production code touched