### PR TITLE
feat: add feature flags for the frontend-consumable API surface (#283)

### DIFF
--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -41,6 +41,14 @@ class Configuration
     final public const FEATURE_RESET_CONTENT_ELEMENT_STATUS_ON_PAGE_RESET = 'resetContentElementStatusOnPageReset';
     final public const FEATURE_COMMENT_TODOS = 'commentTodos';
 
+    /*
+     * Both default to off, so a stock installation exposes no additional surface. They
+     * only control availability — every gated route stays a backend route and still
+     * requires a backend session and a CSRF route token.
+     */
+    final public const FEATURE_FRONTEND_API = 'enableFrontendApi';
+    final public const FEATURE_EMBEDDABLE_COMMENTS_VIEW = 'enableEmbeddableCommentsView';
+
     final public const CACHE_IDENTIFIER = 'ximatypo3contentplanner';
 
     /*

--- a/Classes/Utility/ExtensionUtility.php
+++ b/Classes/Utility/ExtensionUtility.php
@@ -142,6 +142,16 @@ class ExtensionUtility
         return self::isFeatureEnabled('enableContentElementSupport');
     }
 
+    public static function isFrontendApiEnabled(): bool
+    {
+        return self::isFeatureEnabled(Configuration::FEATURE_FRONTEND_API);
+    }
+
+    public static function isEmbeddableCommentsViewEnabled(): bool
+    {
+        return self::isFeatureEnabled(Configuration::FEATURE_EMBEDDABLE_COMMENTS_VIEW);
+    }
+
     public static function isFeatureEnabled(string $feature): bool
     {
         $configuration = GeneralUtility::makeInstance(ExtensionConfiguration::class)

--- a/Documentation/Configuration/ExtensionConfiguration.rst
+++ b/Documentation/Configuration/ExtensionConfiguration.rst
@@ -121,3 +121,28 @@ Comments
         :alt: Todos from comments
 
         Todos from comments
+
+API
+=======
+
+..  _extconf-enableFrontendApi:
+
+..  confval:: enableFrontendApi
+    :type: boolean
+    :Default: 0
+
+    Enable the JSON endpoints for frontend consumers.
+
+    ..  note::
+        See :ref:`Frontend API <frontend-api>` for the security model. The flag
+        controls availability only — the endpoints remain backend routes and
+        still require a backend session and a CSRF route token.
+
+..  _extconf-enableEmbeddableCommentsView:
+
+..  confval:: enableEmbeddableCommentsView
+    :type: boolean
+    :Default: 0
+
+    Enable the embeddable standalone comments view, a backend route rendering a
+    comment thread as a complete HTML document suitable for an ``<iframe>``.

--- a/Documentation/DeveloperCorner/FrontendApi.rst
+++ b/Documentation/DeveloperCorner/FrontendApi.rst
@@ -1,0 +1,96 @@
+..  include:: /Includes.rst.txt
+
+..  _frontend-api:
+
+============
+Frontend API
+============
+
+Beside the backend UI, the content planner can expose a small set of endpoints
+meant to be consumed from other contexts — most notably a frontend editing
+sidebar that renders status badges and comment counters next to the elements
+they belong to.
+
+The whole surface is **disabled by default**. A stock installation behaves
+exactly as it did before these endpoints existed.
+
+..  _frontend-api-flags:
+
+Feature flags
+=============
+
+Two independent :ref:`extension configuration <extension-configuration>` flags
+control availability, both defaulting to ``0``:
+
+:ref:`enableFrontendApi <extconf-enableFrontendApi>`
+    Enables the JSON endpoints for status changes, the status selection and the
+    batched annotation summary.
+
+:ref:`enableEmbeddableCommentsView <extconf-enableEmbeddableCommentsView>`
+    Enables the embeddable comments view, a backend route that renders a comment
+    thread as a complete HTML document suitable for an ``<iframe>``.
+
+They are separate on purpose: the embeddable comments view is useful
+backend-internally as well, so it should not require opening up the JSON API.
+
+..  _frontend-api-security:
+
+Security model
+==============
+
+..  important::
+    The flags control **availability only**. They never replace authentication.
+
+Every endpoint stays a regular TYPO3 **backend route**, which means each request
+is subject to the same checks as any other backend AJAX call:
+
+Backend session
+    The request needs an authenticated backend user. There is no anonymous
+    access and no separate token mechanism — a frontend consumer has to run in a
+    context where the backend session cookie is present.
+
+CSRF route token
+    Backend routes are protected by the core's route token mechanism. Consumers
+    must obtain a valid URI (including its token) rather than assembling the
+    path by hand.
+
+Content planner permissions
+    On top of that, every endpoint applies the extension's own checks —
+    :ref:`visibility and per-record access <permissions>`, and the relevant
+    status and comment permissions. An endpoint never grants more than the
+    equivalent action in the backend UI would.
+
+Because the flags default to off and an unset flag is treated as *off*, the
+surface fails closed: an installation that upgrades without touching its
+configuration keeps the endpoints disabled.
+
+..  note::
+    Newly introduced flags are written to the configuration file only once the
+    :guilabel:`Extension Configuration` form is saved. Until then the value is
+    absent, which is evaluated as disabled.
+
+..  _frontend-api-endpoints:
+
+Endpoints
+=========
+
+..  note::
+    Endpoint contracts are documented alongside their implementation. This
+    section grows as the individual endpoints land.
+
+Checking a flag
+===============
+
+Both flags are available through :ref:`ExtensionUtility <extension_utility>`:
+
+..  code-block:: php
+
+    use Xima\XimaTypo3ContentPlanner\Utility\ExtensionUtility;
+
+    if (ExtensionUtility::isFrontendApiEnabled()) {
+        // …
+    }
+
+    if (ExtensionUtility::isEmbeddableCommentsViewEnabled()) {
+        // …
+    }

--- a/Documentation/DeveloperCorner/Index.rst
+++ b/Documentation/DeveloperCorner/Index.rst
@@ -17,4 +17,5 @@ into the status process.
     AdditionalRecords
     Events
     ExtensionUtility
+    FrontendApi
     PlannerUtility

--- a/Tests/Functional/Utility/ExtensionUtilityTest.php
+++ b/Tests/Functional/Utility/ExtensionUtilityTest.php
@@ -32,6 +32,17 @@ final class ExtensionUtilityTest extends AbstractFunctionalTestCase
         $this->loginBackendUser();
     }
 
+    protected function tearDown(): void
+    {
+        // ExtensionConfiguration reads TYPO3_CONF_VARS live, so flags flipped by a
+        // single test would otherwise leak into the following ones.
+        unset(
+            $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY][Configuration::FEATURE_FRONTEND_API],
+            $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY][Configuration::FEATURE_EMBEDDABLE_COMMENTS_VIEW],
+        );
+        parent::tearDown();
+    }
+
     #[Test]
     public function getRecordTablesAlwaysContainsPages(): void
     {
@@ -76,6 +87,43 @@ final class ExtensionUtilityTest extends AbstractFunctionalTestCase
     public function isFeatureEnabledReturnsFalseForUnknownFeature(): void
     {
         self::assertFalse(ExtensionUtility::isFeatureEnabled('thisFeatureDoesNotExist'));
+    }
+
+    #[Test]
+    public function frontendApiIsDisabledByDefault(): void
+    {
+        self::assertFalse(ExtensionUtility::isFrontendApiEnabled());
+    }
+
+    #[Test]
+    public function embeddableCommentsViewIsDisabledByDefault(): void
+    {
+        self::assertFalse(ExtensionUtility::isEmbeddableCommentsViewEnabled());
+    }
+
+    #[Test]
+    public function frontendApiIsEnabledWhenFlagIsSet(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY][Configuration::FEATURE_FRONTEND_API] = 1;
+
+        self::assertTrue(ExtensionUtility::isFrontendApiEnabled());
+    }
+
+    #[Test]
+    public function embeddableCommentsViewIsEnabledWhenFlagIsSet(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY][Configuration::FEATURE_EMBEDDABLE_COMMENTS_VIEW] = 1;
+
+        self::assertTrue(ExtensionUtility::isEmbeddableCommentsViewEnabled());
+    }
+
+    #[Test]
+    public function frontendApiFlagsAreIndependent(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY][Configuration::FEATURE_FRONTEND_API] = 1;
+
+        self::assertTrue(ExtensionUtility::isFrontendApiEnabled());
+        self::assertFalse(ExtensionUtility::isEmbeddableCommentsViewEnabled());
     }
 
     #[Test]

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -20,3 +20,7 @@ currentAssigneeHighlight = 1
 clearCommentsOnStatusReset = 1
 # cat=comments/enable; type=boolean; label=Parse the todos from comments and show them as separate hint
 commentTodos = 1
+# cat=api/enable; type=boolean; label=Enable the JSON API endpoints for frontend consumers (status change, status selection, annotation summary). They remain backend routes requiring a backend session and a CSRF route token.
+enableFrontendApi = 0
+# cat=api/enable; type=boolean; label=Enable the embeddable standalone comments view, a backend route rendering a comment thread as a complete HTML document suitable for an iframe
+enableEmbeddableCommentsView = 0


### PR DESCRIPTION
Implements #283 (CP-7). This is the foundation for the CP-1/CP-3/CP-4/CP-5 endpoints — it lands first so the security model can be agreed before any endpoint exists.

## Flags

Two **independent** flags, both `= 0`:

| Flag | Gates |
|---|---|
| `enableFrontendApi` | the JSON endpoints — status change (CP-3), status selection (CP-4), annotation summary (CP-5) |
| `enableEmbeddableCommentsView` | the embeddable standalone comments view (CP-1) |

Separate toggles rather than one, as the issue argues: the embeddable view is useful backend-internally too, so it shouldn't require opening up the JSON API.

Available via `ExtensionUtility::isFrontendApiEnabled()` and `ExtensionUtility::isEmbeddableCommentsViewEnabled()`.

## Fail-closed, and why that matters here

Worth flagging for review, because it is non-obvious: a newly added `ext_conf_template.txt` key is **not** written to `config/system/settings.php` by `typo3 extension:setup` or `typo3 cache:flush` — I verified both. It only lands once an admin saves the :guilabel:`Extension Configuration` form.

`isFeatureEnabled()` calls `ExtensionConfiguration->get(EXT_KEY)` with **no path argument**, which returns `$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][$ext]` directly and skips core's lazy path-level sync. So for a not-yet-synced key `array_key_exists()` is false and the helper returns `false`.

For these two default-off flags that is exactly the behaviour we want — an installation that upgrades without touching its configuration keeps the surface disabled. It's called out in a comment on the constants and in the docs. (Note the same pattern would be a bug for any future flag that must default to *on*.)

The Extension Configuration form reads `ext_conf_template.txt` itself, so the toggles are visible to admins immediately either way.

## Route gating

No routes are gated yet — there is nothing to gate. Rather than add an empty conditional block now, the agreed mechanism is **conditional registration in `Configuration/Backend/AjaxRoutes.php`**, so a disabled endpoint simply does not exist in the route collection. No per-action guard, no dead code. The first endpoint PR implements it.

**Correction:** an earlier version of this description claimed core answers an unregistered route with a plain 404. I verified this in a 13.4 backend and it is **wrong** — TYPO3 redirects to the backend shell, so a consumer gets a `200` with an HTML document. That is the same shape as an expired session, so a consumer must check the content type rather than the status code. Documented in #292, which adds the chapter.

## Docs

- New chapter `Documentation/DeveloperCorner/FrontendApi.rst` — flags, security model (backend session, CSRF route token, CP permissions), and the fail-closed note. Endpoint contracts get appended as each endpoint lands.
- New "API" section in `Documentation/Configuration/ExtensionConfiguration.rst` — the canonical `confval` definitions; the new chapter links to them rather than redefining them, so there are no duplicate confval targets.

## Test plan

- [x] 5 new functional tests: both flags default off, both enable when set, and the two are independent
- [x] `tearDown()` unsets the flags — `ExtensionConfiguration->get()` has no runtime cache and nothing restores `TYPO3_CONF_VARS` between tests in a class, so a flipped flag would otherwise leak
- [x] Full suite: 348 tests, 573 assertions, 0 failures (3 pre-existing v14-only skips)
- [x] PHPStan level 6: no errors
- [x] `php-cs-fixer` clean on all changed files
- [x] All doc cross-references resolve; no duplicate `confval` definitions
- [ ] Manual check that both toggles appear under a new "API" tab in the Extension Configuration form

## Note

Depends on nothing, but #289 should land first for a green lint job — `main` currently fails `ddev cgl lint` on two unrelated test files.