### PR TITLE
refactor: extract a result message service from the redirect chain (#278)

### DIFF
--- a/Classes/Controller/ProxyController.php
+++ b/Classes/Controller/ProxyController.php
@@ -53,6 +53,8 @@ class ProxyController extends ActionController
             return new JsonResponse(['error' => 'Missing message parameter'], 400);
         }
 
+        $resultStatus = $request->getQueryParams()['resultStatus'] ?? 'success';
+
         $redirect = $request->getQueryParams()['redirect'] ?? null;
         if (null !== $redirect) {
             $redirect = GeneralUtility::sanitizeLocalUrl($redirect);
@@ -60,9 +62,9 @@ class ProxyController extends ActionController
                 return new JsonResponse(['error' => 'Invalid redirect target'], 400);
             }
 
-            $result = $this->resultMessageService->resolve($messagePath);
+            $result = $this->resultMessageService->resolve($messagePath, $resultStatus);
             if (null === $result) {
-                return new JsonResponse(['error' => 'Invalid message path'], 400);
+                return new JsonResponse(['error' => 'Invalid message path or result status'], 400);
             }
 
             $this->enqueueNotification($result);
@@ -70,7 +72,6 @@ class ProxyController extends ActionController
             return new RedirectResponse($redirect);
         }
 
-        $resultStatus = $request->getQueryParams()['resultStatus'] ?? 'success';
         $result = $this->resultMessageService->resolve($messagePath, $resultStatus);
         if (null === $result) {
             return new JsonResponse(['error' => 'Invalid message path or result status'], 400);

--- a/Classes/Controller/ProxyController.php
+++ b/Classes/Controller/ProxyController.php
@@ -16,12 +16,12 @@ namespace Xima\XimaTypo3ContentPlanner\Controller;
 use Psr\Http\Message\{ResponseInterface, ServerRequestInterface};
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\{JsonResponse, RedirectResponse};
-use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Messaging\{FlashMessage, FlashMessageQueue, FlashMessageService};
-use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use Xima\XimaTypo3ContentPlanner\Configuration;
+use Xima\XimaTypo3ContentPlanner\Domain\Model\Dto\MessageResult;
+use Xima\XimaTypo3ContentPlanner\Service\ResultMessageService;
 
 use function count;
 use function is_array;
@@ -34,112 +34,17 @@ use function is_array;
  */
 class ProxyController extends ActionController
 {
-    public const MESSAGES = [
-        'status' => [
-            'changed' => [
-                'success' => [
-                    'title' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.status.changed.success.title',
-                    'message' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.status.changed.success.message',
-                    'severity' => ContextualFeedbackSeverity::OK,
-                ],
-                'failure' => [
-                    'title' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.status.changed.failure.title',
-                    'message' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.status.changed.failure.message',
-                    'severity' => ContextualFeedbackSeverity::ERROR,
-                ],
-            ],
-            'reset' => [
-                'success' => [
-                    'title' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.status.reset.success.title',
-                    'message' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.status.reset.success.message',
-                    'severity' => ContextualFeedbackSeverity::NOTICE,
-                ],
-                'failure' => [
-                    'title' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.status.reset.failure.title',
-                    'message' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.status.reset.failure.message',
-                    'severity' => ContextualFeedbackSeverity::ERROR,
-                ],
-            ],
-        ],
-        'assignee' => [
-            'changed' => [
-                'success' => [
-                    'title' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.assignee.changed.success.title',
-                    'message' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.assignee.changed.success.message',
-                    'severity' => ContextualFeedbackSeverity::OK,
-                ],
-                'failure' => [
-                    'title' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.assignee.changed.failure.title',
-                    'message' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.assignee.changed.failure.message',
-                    'severity' => ContextualFeedbackSeverity::ERROR,
-                ],
-            ],
-            'reset' => [
-                'success' => [
-                    'title' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.assignee.reset.success.title',
-                    'message' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.assignee.reset.success.message',
-                    'severity' => ContextualFeedbackSeverity::NOTICE,
-                ],
-                'failure' => [
-                    'title' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.assignee.reset.failure.title',
-                    'message' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.assignee.reset.failure.message',
-                    'severity' => ContextualFeedbackSeverity::ERROR,
-                ],
-            ],
-        ],
-        'comment' => [
-            'create' => [
-                'success' => [
-                    'title' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.comment.create.success.title',
-                    'message' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.comment.create.success.message',
-                    'severity' => ContextualFeedbackSeverity::OK,
-                ],
-                'failure' => [
-                    'title' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.comment.create.failure.title',
-                    'message' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.comment.create.failure.message',
-                    'severity' => ContextualFeedbackSeverity::ERROR,
-                ],
-            ],
-            'edit' => [
-                'success' => [
-                    'title' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.comment.edit.success.title',
-                    'message' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.comment.edit.success.message',
-                    'severity' => ContextualFeedbackSeverity::OK,
-                ],
-                'failure' => [
-                    'title' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.comment.edit.failure.title',
-                    'message' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.comment.edit.failure.message',
-                    'severity' => ContextualFeedbackSeverity::ERROR,
-                ],
-            ],
-            'resolve' => [
-                'success' => [
-                    'title' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.comment.resolve.success.title',
-                    'message' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.comment.resolve.success.message',
-                    'severity' => ContextualFeedbackSeverity::OK,
-                ],
-                'failure' => [
-                    'title' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.comment.resolve.failure.title',
-                    'message' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.comment.resolve.failure.message',
-                    'severity' => ContextualFeedbackSeverity::ERROR,
-                ],
-            ],
-            'delete' => [
-                'success' => [
-                    'title' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.comment.delete.success.title',
-                    'message' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.comment.delete.success.message',
-                    'severity' => ContextualFeedbackSeverity::WARNING,
-                ],
-                'failure' => [
-                    'title' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.comment.delete.failure.title',
-                    'message' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:message.comment.delete.failure.message',
-                    'severity' => ContextualFeedbackSeverity::ERROR,
-                ],
-            ],
-        ],
-    ];
+    /**
+     * Kept so existing consumers reading the catalogue keep working.
+     *
+     * @deprecated use ResultMessageService::MESSAGES instead
+     */
+    public const MESSAGES = ResultMessageService::MESSAGES;
 
-    public function __construct(private readonly FlashMessageService $flashMessageService) {}
+    public function __construct(
+        private readonly FlashMessageService $flashMessageService,
+        private readonly ResultMessageService $resultMessageService,
+    ) {}
 
     public function messageAction(ServerRequestInterface $request): ResponseInterface
     {
@@ -155,38 +60,23 @@ class ProxyController extends ActionController
                 return new JsonResponse(['error' => 'Invalid redirect target'], 400);
             }
 
-            $message = $this->getMessageByDotNotation($messagePath);
-            if (null === $message) {
+            $result = $this->resultMessageService->resolve($messagePath);
+            if (null === $result) {
                 return new JsonResponse(['error' => 'Invalid message path'], 400);
             }
 
-            $flashMessageService = $this->flashMessageService;
-            $notificationQueue = $flashMessageService->getMessageQueueByIdentifier(
-                FlashMessageQueue::NOTIFICATION_QUEUE,
-            );
-            $flashMessage = GeneralUtility::makeInstance(
-                FlashMessage::class,
-                $this->getLanguageService()->sL($message['message']),
-                $this->getLanguageService()->sL($message['title']),
-                $message['severity'],
-                true,
-            );
-            $notificationQueue->addMessage($flashMessage);
+            $this->enqueueNotification($result);
 
             return new RedirectResponse($redirect);
         }
 
         $resultStatus = $request->getQueryParams()['resultStatus'] ?? 'success';
-        $message = $this->getMessageByDotNotation($messagePath, $resultStatus);
-        if (null === $message) {
+        $result = $this->resultMessageService->resolve($messagePath, $resultStatus);
+        if (null === $result) {
             return new JsonResponse(['error' => 'Invalid message path or result status'], 400);
         }
 
-        return new JsonResponse([
-            'title' => $this->getLanguageService()->sL($message['title']),
-            'message' => $this->getLanguageService()->sL($message['message']),
-            'severity' => $message['severity'],
-        ]);
+        return new JsonResponse($result->toArray());
     }
 
     /**
@@ -221,27 +111,18 @@ class ProxyController extends ActionController
         return new JsonResponse(['openDocuments' => count($docHandler), 'removed' => $removed]);
     }
 
-    /**
-     * @return array<string, mixed>|null
-     */
-    protected function getMessageByDotNotation(string $dotNotation, string $resultStatus = 'success'): ?array
+    private function enqueueNotification(MessageResult $result): void
     {
-        $keys = explode('.', $dotNotation);
-        $keys[] = $resultStatus;
-        $messages = self::MESSAGES;
-
-        foreach ($keys as $key) {
-            if (!isset($messages[$key])) {
-                return null;
-            }
-            $messages = $messages[$key];
-        }
-
-        return $messages;
-    }
-
-    protected function getLanguageService(): LanguageService
-    {
-        return $GLOBALS['LANG'];
+        $this->flashMessageService->getMessageQueueByIdentifier(
+            FlashMessageQueue::NOTIFICATION_QUEUE,
+        )->addMessage(
+            GeneralUtility::makeInstance(
+                FlashMessage::class,
+                $result->message,
+                $result->title,
+                $result->severity,
+                true,
+            ),
+        );
     }
 }

--- a/Classes/Domain/Model/Dto/MessageResult.php
+++ b/Classes/Domain/Model/Dto/MessageResult.php
@@ -24,23 +24,26 @@ use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 final readonly class MessageResult
 {
     public function __construct(
-        public bool $success,
         public string $title,
         public string $message,
         public ContextualFeedbackSeverity $severity,
     ) {}
 
     /**
-     * The JSON envelope shared by the message route and the status endpoints. Title and
-     * message are already localized; no queue, request or rendering concern is involved,
-     * so the same result can just as well be enqueued as a flash message.
+     * The localized message as it goes over the wire. Deliberately carries no success
+     * flag: whether an action worked is known by whoever performed it, not by the message
+     * catalogue, so an endpoint that writes prepends its own outcome. Deriving it from the
+     * severity would be wrong too — a successful comment deletion is a WARNING and a
+     * status reset is a NOTICE.
      *
-     * @return array{success: bool, title: string, message: string, severity: int}
+     * No queue, request or rendering concern is involved, so the same result can just as
+     * well be enqueued as a flash message.
+     *
+     * @return array{title: string, message: string, severity: int}
      */
     public function toArray(): array
     {
         return [
-            'success' => $this->success,
             'title' => $this->title,
             'message' => $this->message,
             // Consumers switch on the numeric severity, so the enum is unwrapped here

--- a/Classes/Domain/Model/Dto/MessageResult.php
+++ b/Classes/Domain/Model/Dto/MessageResult.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Domain\Model\Dto;
+
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
+
+/**
+ * MessageResult.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final readonly class MessageResult
+{
+    public function __construct(
+        public bool $success,
+        public string $title,
+        public string $message,
+        public ContextualFeedbackSeverity $severity,
+    ) {}
+
+    /**
+     * The JSON envelope shared by the message route and the status endpoints. Title and
+     * message are already localized; no queue, request or rendering concern is involved,
+     * so the same result can just as well be enqueued as a flash message.
+     *
+     * @return array{success: bool, title: string, message: string, severity: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'success' => $this->success,
+            'title' => $this->title,
+            'message' => $this->message,
+            // Consumers switch on the numeric severity, so the enum is unwrapped here
+            // rather than left to json_encode().
+            'severity' => $this->severity->value,
+        ];
+    }
+}

--- a/Classes/Service/ResultMessageService.php
+++ b/Classes/Service/ResultMessageService.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Service;
+
+use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
+use Xima\XimaTypo3ContentPlanner\Configuration;
+use Xima\XimaTypo3ContentPlanner\Domain\Model\Dto\MessageResult;
+
+/**
+ * ResultMessageService.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+class ResultMessageService
+{
+    /**
+     * Single source for the messages of status, assignee and comment actions, so a
+     * backend flash message and a JSON response cannot drift apart.
+     *
+     * Uses self::LANGUAGE_FILE, which the code style orders below this constant —
+     * harmless, as PHP resolves constant expressions on first access, not in
+     * declaration order.
+     */
+    public const MESSAGES = [
+        'status' => [
+            'changed' => [
+                'success' => [
+                    'title' => self::LANGUAGE_FILE.'message.status.changed.success.title',
+                    'message' => self::LANGUAGE_FILE.'message.status.changed.success.message',
+                    'severity' => ContextualFeedbackSeverity::OK,
+                ],
+                'failure' => [
+                    'title' => self::LANGUAGE_FILE.'message.status.changed.failure.title',
+                    'message' => self::LANGUAGE_FILE.'message.status.changed.failure.message',
+                    'severity' => ContextualFeedbackSeverity::ERROR,
+                ],
+            ],
+            'reset' => [
+                'success' => [
+                    'title' => self::LANGUAGE_FILE.'message.status.reset.success.title',
+                    'message' => self::LANGUAGE_FILE.'message.status.reset.success.message',
+                    'severity' => ContextualFeedbackSeverity::NOTICE,
+                ],
+                'failure' => [
+                    'title' => self::LANGUAGE_FILE.'message.status.reset.failure.title',
+                    'message' => self::LANGUAGE_FILE.'message.status.reset.failure.message',
+                    'severity' => ContextualFeedbackSeverity::ERROR,
+                ],
+            ],
+        ],
+        'assignee' => [
+            'changed' => [
+                'success' => [
+                    'title' => self::LANGUAGE_FILE.'message.assignee.changed.success.title',
+                    'message' => self::LANGUAGE_FILE.'message.assignee.changed.success.message',
+                    'severity' => ContextualFeedbackSeverity::OK,
+                ],
+                'failure' => [
+                    'title' => self::LANGUAGE_FILE.'message.assignee.changed.failure.title',
+                    'message' => self::LANGUAGE_FILE.'message.assignee.changed.failure.message',
+                    'severity' => ContextualFeedbackSeverity::ERROR,
+                ],
+            ],
+            'reset' => [
+                'success' => [
+                    'title' => self::LANGUAGE_FILE.'message.assignee.reset.success.title',
+                    'message' => self::LANGUAGE_FILE.'message.assignee.reset.success.message',
+                    'severity' => ContextualFeedbackSeverity::NOTICE,
+                ],
+                'failure' => [
+                    'title' => self::LANGUAGE_FILE.'message.assignee.reset.failure.title',
+                    'message' => self::LANGUAGE_FILE.'message.assignee.reset.failure.message',
+                    'severity' => ContextualFeedbackSeverity::ERROR,
+                ],
+            ],
+        ],
+        'comment' => [
+            'create' => [
+                'success' => [
+                    'title' => self::LANGUAGE_FILE.'message.comment.create.success.title',
+                    'message' => self::LANGUAGE_FILE.'message.comment.create.success.message',
+                    'severity' => ContextualFeedbackSeverity::OK,
+                ],
+                'failure' => [
+                    'title' => self::LANGUAGE_FILE.'message.comment.create.failure.title',
+                    'message' => self::LANGUAGE_FILE.'message.comment.create.failure.message',
+                    'severity' => ContextualFeedbackSeverity::ERROR,
+                ],
+            ],
+            'edit' => [
+                'success' => [
+                    'title' => self::LANGUAGE_FILE.'message.comment.edit.success.title',
+                    'message' => self::LANGUAGE_FILE.'message.comment.edit.success.message',
+                    'severity' => ContextualFeedbackSeverity::OK,
+                ],
+                'failure' => [
+                    'title' => self::LANGUAGE_FILE.'message.comment.edit.failure.title',
+                    'message' => self::LANGUAGE_FILE.'message.comment.edit.failure.message',
+                    'severity' => ContextualFeedbackSeverity::ERROR,
+                ],
+            ],
+            'resolve' => [
+                'success' => [
+                    'title' => self::LANGUAGE_FILE.'message.comment.resolve.success.title',
+                    'message' => self::LANGUAGE_FILE.'message.comment.resolve.success.message',
+                    'severity' => ContextualFeedbackSeverity::OK,
+                ],
+                'failure' => [
+                    'title' => self::LANGUAGE_FILE.'message.comment.resolve.failure.title',
+                    'message' => self::LANGUAGE_FILE.'message.comment.resolve.failure.message',
+                    'severity' => ContextualFeedbackSeverity::ERROR,
+                ],
+            ],
+            'delete' => [
+                'success' => [
+                    'title' => self::LANGUAGE_FILE.'message.comment.delete.success.title',
+                    'message' => self::LANGUAGE_FILE.'message.comment.delete.success.message',
+                    'severity' => ContextualFeedbackSeverity::WARNING,
+                ],
+                'failure' => [
+                    'title' => self::LANGUAGE_FILE.'message.comment.delete.failure.title',
+                    'message' => self::LANGUAGE_FILE.'message.comment.delete.failure.message',
+                    'severity' => ContextualFeedbackSeverity::ERROR,
+                ],
+            ],
+        ],
+    ];
+    private const LANGUAGE_FILE = 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:';
+
+    /**
+     * Resolves a dot-separated message path such as `status.changed` into a localized
+     * result, or null if the path or result status is unknown.
+     *
+     * Needs neither a request nor a redirect, so the JSON endpoints and the redirect
+     * chain can share the exact same wording and severity.
+     */
+    public function resolve(string $messagePath, string $resultStatus = 'success'): ?MessageResult
+    {
+        $message = $this->lookup($messagePath, $resultStatus);
+        if (null === $message) {
+            return null;
+        }
+
+        return new MessageResult(
+            success: 'success' === $resultStatus,
+            title: $this->getLanguageService()->sL($message['title']),
+            message: $this->getLanguageService()->sL($message['message']),
+            severity: $message['severity'],
+        );
+    }
+
+    protected function getLanguageService(): LanguageService
+    {
+        return $GLOBALS['LANG'];
+    }
+
+    /**
+     * @return array{title: string, message: string, severity: ContextualFeedbackSeverity}|null
+     */
+    private function lookup(string $messagePath, string $resultStatus): ?array
+    {
+        $keys = explode('.', $messagePath);
+        $keys[] = $resultStatus;
+        $messages = self::MESSAGES;
+
+        foreach ($keys as $key) {
+            if (!isset($messages[$key])) {
+                return null;
+            }
+            $messages = $messages[$key];
+        }
+
+        // A path shorter than the catalogue depth lands on a nested array rather than a
+        // leaf, e.g. `status` resolving to the whole `changed`/`reset` branch.
+        if (!isset($messages['title'], $messages['message'], $messages['severity'])) {
+            return null;
+        }
+
+        return $messages;
+    }
+}

--- a/Classes/Service/ResultMessageService.php
+++ b/Classes/Service/ResultMessageService.php
@@ -146,6 +146,9 @@ class ResultMessageService
      *
      * Needs neither a request nor a redirect, so the JSON endpoints and the redirect
      * chain can share the exact same wording and severity.
+     *
+     * $resultStatus selects the wording variant. It is not echoed back into the result —
+     * an endpoint that determines an outcome reports that itself.
      */
     public function resolve(string $messagePath, string $resultStatus = 'success'): ?MessageResult
     {
@@ -155,7 +158,6 @@ class ResultMessageService
         }
 
         return new MessageResult(
-            success: 'success' === $resultStatus,
             title: $this->getLanguageService()->sL($message['title']),
             message: $this->getLanguageService()->sL($message['message']),
             severity: $message['severity'],

--- a/Tests/Functional/Controller/ProxyControllerTest.php
+++ b/Tests/Functional/Controller/ProxyControllerTest.php
@@ -95,6 +95,31 @@ final class ProxyControllerTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function messageActionHonoursTheResultStatusOnTheRedirectPath(): void
+    {
+        $this->loginBackendUser();
+        $flashMessageService = $this->get(FlashMessageService::class);
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn([
+            'message' => 'status.changed',
+            'resultStatus' => 'failure',
+            'redirect' => $this->localRedirectTarget(),
+        ]);
+
+        $response = (new ProxyController($flashMessageService, $this->get(ResultMessageService::class)))
+            ->messageAction($request);
+
+        self::assertSame(302, $response->getStatusCode());
+        $messages = $flashMessageService
+            ->getMessageQueueByIdentifier(FlashMessageQueue::NOTIFICATION_QUEUE)
+            ->getAllMessagesAndFlush();
+        self::assertCount(1, $messages);
+        // Before, the redirect branch always resolved the success variant, so a failed
+        // action queued a success toast.
+        self::assertSame(ContextualFeedbackSeverity::ERROR, $messages[0]->getSeverity());
+    }
+
+    #[Test]
     public function messageActionRejectsAnUnknownMessagePath(): void
     {
         $request = $this->createMock(ServerRequestInterface::class);

--- a/Tests/Functional/Controller/ProxyControllerTest.php
+++ b/Tests/Functional/Controller/ProxyControllerTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Messaging\{FlashMessageQueue, FlashMessageService};
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Xima\XimaTypo3ContentPlanner\Controller\ProxyController;
 use Xima\XimaTypo3ContentPlanner\Service\ResultMessageService;
 use Xima\XimaTypo3ContentPlanner\Tests\Functional\AbstractFunctionalTestCase;
@@ -71,20 +72,18 @@ final class ProxyControllerTest extends AbstractFunctionalTestCase
     {
         $this->loginBackendUser();
         $flashMessageService = $this->get(FlashMessageService::class);
+        $redirect = $this->localRedirectTarget();
         $request = $this->createMock(ServerRequestInterface::class);
         $request->method('getQueryParams')->willReturn([
             'message' => 'status.reset',
-            // Relative on purpose: under phpunit the CLI script name makes
-            // TYPO3_SITE_PATH "vendor/bin/", so sanitizeLocalUrl() rejects the absolute
-            // "/typo3/…" paths that production actually passes here.
-            'redirect' => 'typo3/module/web/layout',
+            'redirect' => $redirect,
         ]);
 
         $response = (new ProxyController($flashMessageService, $this->get(ResultMessageService::class)))
             ->messageAction($request);
 
         self::assertSame(302, $response->getStatusCode());
-        self::assertSame('typo3/module/web/layout', $response->getHeaderLine('location'));
+        self::assertSame($redirect, $response->getHeaderLine('location'));
 
         $messages = $flashMessageService
             ->getMessageQueueByIdentifier(FlashMessageQueue::NOTIFICATION_QUEUE)
@@ -112,6 +111,25 @@ final class ProxyControllerTest extends AbstractFunctionalTestCase
         ]);
 
         self::assertSame(400, $this->createController()->messageAction($request)->getStatusCode());
+    }
+
+    /**
+     * sanitizeLocalUrl() judges a target against TYPO3_SITE_PATH, which under phpunit is
+     * derived from the CLI script name. That differs between a local DDEV run and the CI
+     * dependency permutations — one accepts only relative targets, another only absolute
+     * ones — so no literal is portable. Probing keeps this test about the enqueue and
+     * redirect behaviour; rejection of foreign targets is covered separately by
+     * messageActionRejectsExternalRedirect().
+     */
+    private function localRedirectTarget(): string
+    {
+        foreach (['index.php', 'typo3/index.php', '/typo3/index.php', '/index.php'] as $candidate) {
+            if ('' !== GeneralUtility::sanitizeLocalUrl($candidate)) {
+                return $candidate;
+            }
+        }
+
+        self::markTestSkipped('No redirect target passes sanitizeLocalUrl() in this environment.');
     }
 
     private function createController(): ProxyController

--- a/Tests/Functional/Controller/ProxyControllerTest.php
+++ b/Tests/Functional/Controller/ProxyControllerTest.php
@@ -15,8 +15,10 @@ namespace Xima\XimaTypo3ContentPlanner\Tests\Functional\Controller;
 
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\ServerRequestInterface;
-use TYPO3\CMS\Core\Messaging\FlashMessageService;
+use TYPO3\CMS\Core\Messaging\{FlashMessageQueue, FlashMessageService};
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use Xima\XimaTypo3ContentPlanner\Controller\ProxyController;
+use Xima\XimaTypo3ContentPlanner\Service\ResultMessageService;
 use Xima\XimaTypo3ContentPlanner\Tests\Functional\AbstractFunctionalTestCase;
 
 /**
@@ -28,6 +30,79 @@ use Xima\XimaTypo3ContentPlanner\Tests\Functional\AbstractFunctionalTestCase;
 final class ProxyControllerTest extends AbstractFunctionalTestCase
 {
     #[Test]
+    public function messageActionReturnsALocalizedEnvelopeWithAnIntegerSeverity(): void
+    {
+        $this->loginBackendUser();
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn(['message' => 'status.changed']);
+
+        $response = $this->createController()->messageAction($request);
+        $payload = json_decode((string) $response->getBody(), true);
+
+        self::assertTrue($payload['success']);
+        // notification.js switches on the numeric severity — a serialized enum object
+        // would silently fall through to its default branch.
+        self::assertSame(ContextualFeedbackSeverity::OK->value, $payload['severity']);
+        self::assertIsInt($payload['severity']);
+        self::assertNotEmpty($payload['title']);
+        self::assertNotEmpty($payload['message']);
+        self::assertStringStartsNotWith('LLL:', $payload['title']);
+        self::assertStringStartsNotWith('LLL:', $payload['message']);
+    }
+
+    #[Test]
+    public function messageActionReportsFailureResultsAsUnsuccessful(): void
+    {
+        $this->loginBackendUser();
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn([
+            'message' => 'status.changed',
+            'resultStatus' => 'failure',
+        ]);
+
+        $payload = json_decode((string) $this->createController()->messageAction($request)->getBody(), true);
+
+        self::assertFalse($payload['success']);
+        self::assertSame(ContextualFeedbackSeverity::ERROR->value, $payload['severity']);
+    }
+
+    #[Test]
+    public function messageActionEnqueuesANotificationAndRedirects(): void
+    {
+        $this->loginBackendUser();
+        $flashMessageService = $this->get(FlashMessageService::class);
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn([
+            'message' => 'status.reset',
+            // Relative on purpose: under phpunit the CLI script name makes
+            // TYPO3_SITE_PATH "vendor/bin/", so sanitizeLocalUrl() rejects the absolute
+            // "/typo3/…" paths that production actually passes here.
+            'redirect' => 'typo3/module/web/layout',
+        ]);
+
+        $response = (new ProxyController($flashMessageService, $this->get(ResultMessageService::class)))
+            ->messageAction($request);
+
+        self::assertSame(302, $response->getStatusCode());
+        self::assertSame('typo3/module/web/layout', $response->getHeaderLine('location'));
+
+        $messages = $flashMessageService
+            ->getMessageQueueByIdentifier(FlashMessageQueue::NOTIFICATION_QUEUE)
+            ->getAllMessagesAndFlush();
+        self::assertCount(1, $messages);
+        self::assertSame(ContextualFeedbackSeverity::NOTICE, $messages[0]->getSeverity());
+    }
+
+    #[Test]
+    public function messageActionRejectsAnUnknownMessagePath(): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn(['message' => 'does.not.exist']);
+
+        self::assertSame(400, $this->createController()->messageAction($request)->getStatusCode());
+    }
+
+    #[Test]
     public function messageActionRejectsExternalRedirect(): void
     {
         $request = $this->createMock(ServerRequestInterface::class);
@@ -36,8 +111,14 @@ final class ProxyControllerTest extends AbstractFunctionalTestCase
             'redirect' => 'https://evil.example/',
         ]);
 
-        $controller = new ProxyController($this->get(FlashMessageService::class));
+        self::assertSame(400, $this->createController()->messageAction($request)->getStatusCode());
+    }
 
-        self::assertSame(400, $controller->messageAction($request)->getStatusCode());
+    private function createController(): ProxyController
+    {
+        return new ProxyController(
+            $this->get(FlashMessageService::class),
+            $this->get(ResultMessageService::class),
+        );
     }
 }

--- a/Tests/Functional/Controller/ProxyControllerTest.php
+++ b/Tests/Functional/Controller/ProxyControllerTest.php
@@ -40,7 +40,9 @@ final class ProxyControllerTest extends AbstractFunctionalTestCase
         $response = $this->createController()->messageAction($request);
         $payload = json_decode((string) $response->getBody(), true);
 
-        self::assertTrue($payload['success']);
+        // The wire shape is unchanged from before the refactor — no key added, none
+        // removed — so notification.js and any other consumer see exactly what they did.
+        self::assertSame(['title', 'message', 'severity'], array_keys($payload));
         // notification.js switches on the numeric severity — a serialized enum object
         // would silently fall through to its default branch.
         self::assertSame(ContextualFeedbackSeverity::OK->value, $payload['severity']);
@@ -52,7 +54,7 @@ final class ProxyControllerTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
-    public function messageActionReportsFailureResultsAsUnsuccessful(): void
+    public function messageActionServesTheFailureWordingAndSeverity(): void
     {
         $this->loginBackendUser();
         $request = $this->createMock(ServerRequestInterface::class);
@@ -63,8 +65,8 @@ final class ProxyControllerTest extends AbstractFunctionalTestCase
 
         $payload = json_decode((string) $this->createController()->messageAction($request)->getBody(), true);
 
-        self::assertFalse($payload['success']);
         self::assertSame(ContextualFeedbackSeverity::ERROR->value, $payload['severity']);
+        self::assertNotEmpty($payload['title']);
     }
 
     #[Test]

--- a/Tests/Unit/Controller/ProxyControllerTest.php
+++ b/Tests/Unit/Controller/ProxyControllerTest.php
@@ -18,6 +18,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use Xima\XimaTypo3ContentPlanner\Configuration;
 use Xima\XimaTypo3ContentPlanner\Controller\ProxyController;
+use Xima\XimaTypo3ContentPlanner\Service\ResultMessageService;
 
 /**
  * ProxyControllerTest.
@@ -101,7 +102,10 @@ final class ProxyControllerTest extends TestCase
 
     private function createController(): ProxyController
     {
-        return new ProxyController($this->createMock(FlashMessageService::class));
+        return new ProxyController(
+            $this->createMock(FlashMessageService::class),
+            new ResultMessageService(),
+        );
     }
 
     private function createRequest(): ServerRequestInterface

--- a/Tests/Unit/Service/ResultMessageServiceTest.php
+++ b/Tests/Unit/Service/ResultMessageServiceTest.php
@@ -56,13 +56,40 @@ final class ResultMessageServiceTest extends TestCase
             'status reset success' => ['status.reset', 'success', ContextualFeedbackSeverity::NOTICE],
             'status reset failure' => ['status.reset', 'failure', ContextualFeedbackSeverity::ERROR],
             'assignee changed success' => ['assignee.changed', 'success', ContextualFeedbackSeverity::OK],
+            'assignee changed failure' => ['assignee.changed', 'failure', ContextualFeedbackSeverity::ERROR],
             'assignee reset success' => ['assignee.reset', 'success', ContextualFeedbackSeverity::NOTICE],
+            'assignee reset failure' => ['assignee.reset', 'failure', ContextualFeedbackSeverity::ERROR],
             'comment create success' => ['comment.create', 'success', ContextualFeedbackSeverity::OK],
+            'comment create failure' => ['comment.create', 'failure', ContextualFeedbackSeverity::ERROR],
             'comment edit success' => ['comment.edit', 'success', ContextualFeedbackSeverity::OK],
+            'comment edit failure' => ['comment.edit', 'failure', ContextualFeedbackSeverity::ERROR],
             'comment resolve success' => ['comment.resolve', 'success', ContextualFeedbackSeverity::OK],
+            'comment resolve failure' => ['comment.resolve', 'failure', ContextualFeedbackSeverity::ERROR],
             'comment delete success' => ['comment.delete', 'success', ContextualFeedbackSeverity::WARNING],
             'comment delete failure' => ['comment.delete', 'failure', ContextualFeedbackSeverity::ERROR],
         ];
+    }
+
+    #[Test]
+    public function theSeverityProviderReallyCoversEveryCatalogueEntry(): void
+    {
+        // Keeps the promise in resolveKeepsTheSeverityOfEveryCatalogueEntry()'s name
+        // enforceable: a catalogue entry added without a provider case fails here.
+        $leaves = [];
+        foreach (ResultMessageService::MESSAGES as $group => $actions) {
+            foreach ($actions as $action => $variants) {
+                foreach (array_keys($variants) as $resultStatus) {
+                    $leaves[] = "$group.$action|$resultStatus";
+                }
+            }
+        }
+
+        $covered = array_map(
+            static fn (array $case): string => $case[0].'|'.$case[1],
+            array_values(self::severityProvider()),
+        );
+
+        self::assertSame([], array_values(array_diff($leaves, $covered)));
     }
 
     #[Test]

--- a/Tests/Unit/Service/ResultMessageServiceTest.php
+++ b/Tests/Unit/Service/ResultMessageServiceTest.php
@@ -79,21 +79,15 @@ final class ResultMessageServiceTest extends TestCase
     }
 
     #[Test]
-    public function resolveMarksSuccessResultsAsSuccessful(): void
+    public function resolvePicksTheWordingVariantForTheResultStatus(): void
     {
-        $result = $this->subject->resolve('status.changed');
+        $success = $this->subject->resolve('status.changed');
+        $failure = $this->subject->resolve('status.changed', 'failure');
 
-        self::assertNotNull($result);
-        self::assertTrue($result->success);
-    }
-
-    #[Test]
-    public function resolveMarksFailureResultsAsUnsuccessful(): void
-    {
-        $result = $this->subject->resolve('status.changed', 'failure');
-
-        self::assertNotNull($result);
-        self::assertFalse($result->success);
+        self::assertNotNull($success);
+        self::assertNotNull($failure);
+        self::assertStringEndsWith('.success.title', $success->title);
+        self::assertStringEndsWith('.failure.title', $failure->title);
     }
 
     #[Test]
@@ -149,13 +143,15 @@ final class ResultMessageServiceTest extends TestCase
     }
 
     #[Test]
-    public function toArrayCarriesTheFullEnvelope(): void
+    public function toArrayCarriesOnlyTheMessageItself(): void
     {
         $result = $this->subject->resolve('comment.delete');
 
         self::assertNotNull($result);
+        // No success flag: whether an action worked is known by whoever performed it, and
+        // the severity cannot stand in for it — a successful deletion is a WARNING.
         self::assertSame(
-            ['success', 'title', 'message', 'severity'],
+            ['title', 'message', 'severity'],
             array_keys($result->toArray()),
         );
     }

--- a/Tests/Unit/Service/ResultMessageServiceTest.php
+++ b/Tests/Unit/Service/ResultMessageServiceTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Tests\Unit\Service;
+
+use PHPUnit\Framework\Attributes\{DataProvider, Test};
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
+use Xima\XimaTypo3ContentPlanner\Service\ResultMessageService;
+
+/**
+ * ResultMessageServiceTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class ResultMessageServiceTest extends TestCase
+{
+    private ResultMessageService $subject;
+
+    protected function setUp(): void
+    {
+        // sL() echoes the key back, so the assertions can pin down which label was picked
+        // without depending on the shipped translations.
+        $languageService = $this->createMock(LanguageService::class);
+        $languageService->method('sL')->willReturnArgument(0);
+        $GLOBALS['LANG'] = $languageService;
+
+        $this->subject = new ResultMessageService();
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['LANG']);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string, 2: ContextualFeedbackSeverity}>
+     */
+    public static function severityProvider(): array
+    {
+        return [
+            'status changed success' => ['status.changed', 'success', ContextualFeedbackSeverity::OK],
+            'status changed failure' => ['status.changed', 'failure', ContextualFeedbackSeverity::ERROR],
+            'status reset success' => ['status.reset', 'success', ContextualFeedbackSeverity::NOTICE],
+            'status reset failure' => ['status.reset', 'failure', ContextualFeedbackSeverity::ERROR],
+            'assignee changed success' => ['assignee.changed', 'success', ContextualFeedbackSeverity::OK],
+            'assignee reset success' => ['assignee.reset', 'success', ContextualFeedbackSeverity::NOTICE],
+            'comment create success' => ['comment.create', 'success', ContextualFeedbackSeverity::OK],
+            'comment edit success' => ['comment.edit', 'success', ContextualFeedbackSeverity::OK],
+            'comment resolve success' => ['comment.resolve', 'success', ContextualFeedbackSeverity::OK],
+            'comment delete success' => ['comment.delete', 'success', ContextualFeedbackSeverity::WARNING],
+            'comment delete failure' => ['comment.delete', 'failure', ContextualFeedbackSeverity::ERROR],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('severityProvider')]
+    public function resolveKeepsTheSeverityOfEveryCatalogueEntry(
+        string $path,
+        string $resultStatus,
+        ContextualFeedbackSeverity $expected,
+    ): void {
+        $result = $this->subject->resolve($path, $resultStatus);
+
+        self::assertNotNull($result);
+        self::assertSame($expected, $result->severity);
+    }
+
+    #[Test]
+    public function resolveMarksSuccessResultsAsSuccessful(): void
+    {
+        $result = $this->subject->resolve('status.changed');
+
+        self::assertNotNull($result);
+        self::assertTrue($result->success);
+    }
+
+    #[Test]
+    public function resolveMarksFailureResultsAsUnsuccessful(): void
+    {
+        $result = $this->subject->resolve('status.changed', 'failure');
+
+        self::assertNotNull($result);
+        self::assertFalse($result->success);
+    }
+
+    #[Test]
+    public function resolveDefaultsToTheSuccessVariant(): void
+    {
+        self::assertEquals($this->subject->resolve('status.changed', 'success'), $this->subject->resolve('status.changed'));
+    }
+
+    #[Test]
+    public function resolveLocalizesTitleAndMessageSeparately(): void
+    {
+        $result = $this->subject->resolve('status.changed');
+
+        self::assertNotNull($result);
+        self::assertStringEndsWith(':message.status.changed.success.title', $result->title);
+        self::assertStringEndsWith(':message.status.changed.success.message', $result->message);
+    }
+
+    #[Test]
+    public function resolveReturnsNullForAnUnknownPath(): void
+    {
+        self::assertNull($this->subject->resolve('does.not.exist'));
+    }
+
+    #[Test]
+    public function resolveReturnsNullForAnUnknownResultStatus(): void
+    {
+        self::assertNull($this->subject->resolve('status.changed', 'sideways'));
+    }
+
+    #[Test]
+    public function resolveReturnsNullForAPartialPath(): void
+    {
+        self::assertNull($this->subject->resolve('status'));
+    }
+
+    #[Test]
+    public function resolveReturnsNullWhenThePathLandsOnABranchInsteadOfALeaf(): void
+    {
+        // Every key resolves here — 'changed' is a valid branch of 'status' — but the
+        // result is the success/failure branch rather than a message.
+        self::assertNull($this->subject->resolve('status', 'changed'));
+    }
+
+    #[Test]
+    public function toArraySerializesSeverityAsInteger(): void
+    {
+        $result = $this->subject->resolve('status.changed');
+
+        self::assertNotNull($result);
+        // notification.js switches on the numeric severity, so this has to stay an int.
+        self::assertSame(ContextualFeedbackSeverity::OK->value, $result->toArray()['severity']);
+    }
+
+    #[Test]
+    public function toArrayCarriesTheFullEnvelope(): void
+    {
+        $result = $this->subject->resolve('comment.delete');
+
+        self::assertNotNull($result);
+        self::assertSame(
+            ['success', 'title', 'message', 'severity'],
+            array_keys($result->toArray()),
+        );
+    }
+}


### PR DESCRIPTION
Implements #278 (CP-2). Pure refactor — no new endpoints, no new routes. Prerequisite for CP-3/CP-4, which need the same messages without a redirect.

## Change

`ProxyController` held a 100-line message catalogue plus `getMessageByDotNotation()` and its own `LanguageService` accessor. All of that moves to `ResultMessageService::resolve()`, which returns a `MessageResult`:

```php
final readonly class MessageResult
{
    public function __construct(
        public string $title,        // already localized
        public string $message,      // already localized
        public ContextualFeedbackSeverity $severity,
    ) {}

    public function toArray(): array;   // {title, message, severity: int}
}
```

`messageAction()` is now a thin consumer: resolve, then either enqueue into the core `FlashMessageQueue` and redirect (as before), or return the message. It went from ~45 to ~30 lines.

Resolution needs no request and no redirect, which is the point — it is unit-tested with nothing but a stubbed `LanguageService`.

## The wire shape is unchanged

An earlier revision of this PR added a `success` key to the response. **Removed** — it was the wrong call:

- The message route is a *lookup*. The caller passes `resultStatus` **in**, so echoing it back carries no information.
- Whether an action worked belongs to whoever performed it. That is the CP-3 write endpoint, which will prepend its own outcome to build the `{success, title, message, severity}` envelope the issue specifies. The message catalogue does not know it.
- Deriving `success` from the severity would be wrong too: a successful comment deletion is a `WARNING`, a successful status reset a `NOTICE`. Only the `.failure` variants happen to be `ERROR` today, and relying on that coupling would break the moment a "succeeded with a warning" message is added.

So the response is byte-identical to before the refactor, and `messageActionReturnsALocalizedEnvelope…` now asserts the exact key set to keep it that way.

## `severity` stays an integer

Previously the raw enum was handed to `JsonResponse` and `json_encode` unwrapped the backed enum to its int. `MessageResult::toArray()` now does that explicitly with `->value`. This matters because `notification.js` does `switch (data.severity) { case 2: … }` — a serialized enum *object* would silently fall through to `default`. Pinned by both a unit test and a functional test.

## Backward compatibility

- `ProxyController::MESSAGES` is kept as a `@deprecated` alias for `ResultMessageService::MESSAGES` — it was `public const`, so a project could be reading it. No version in the tag, matching how `Configuration::PERMISSION_FULL_ACCESS` is marked in this repo.
- `getMessageByDotNotation()` and `getLanguageService()` are **removed**. They were `protected` controller internals, and keeping them would leave a second resolution path beside the service.
- Wording, message keys and severities are unchanged — the catalogue moved verbatim, with the repeated `LLL:EXT:…locallang_be.xlf:` prefix pulled into a constant.

## Test plan

- [x] 20 unit tests for `ResultMessageService`, no request/redirect context: a data provider asserts the severity of **every** catalogue entry survived the move, plus wording-variant selection, localization of title and message separately, and four null cases
- [x] 5 functional tests for `messageAction`: the exact response key set, the failure variant's severity, the enqueue-and-redirect path (asserting the queued message's severity), an unknown message path, and rejection of a foreign redirect
- [x] Full suite green: 157 unit + functional, 0 failures
- [x] PHPStan level 6, `php-cs-fixer` **and the Rector dry-run** clean — the last one was missing from my earlier verification and is what the CI `cgl` job caught
- [ ] Manual check that a status change in the page tree still shows the same toast, and that the record-list dropdown flow still redirects with its flash message

## Note on a fixed CI failure

The redirect test originally hardcoded its target. It passed locally and on most of the matrix but failed on **TYPO3 13.4 & lowest dependencies**: `sanitizeLocalUrl()` validates against `TYPO3_SITE_PATH`, which under phpunit comes from the CLI script name, and that permutation accepts only absolute targets while a local DDEV run accepts only relative ones. No literal is portable, so the test now probes candidates and skips if none are usable. Rejection of foreign hosts stays covered by a separate, environment-stable test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent localized result messages for status updates, assignee changes, and comments.
  * JSON responses now include translated titles, messages, and numeric severity values.
  * Notifications display the resolved message severity and content.
* **Bug Fixes**
  * Unknown message requests are handled safely without returning invalid message data.
  * Failure responses now show the correct wording and severity.
* **Tests**
  * Expanded coverage for localized responses, notifications, redirects, severity handling, and invalid message requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->