### PR TITLE
feat: add a batched annotation summary endpoint (#281)

### DIFF
--- a/Classes/Controller/ApiController.php
+++ b/Classes/Controller/ApiController.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Controller;
+
+use Psr\Http\Message\{ResponseInterface, ServerRequestInterface};
+use TYPO3\CMS\Core\Http\JsonResponse;
+use Xima\XimaTypo3ContentPlanner\Domain\Model\Dto\Summary\RecordSummary;
+use Xima\XimaTypo3ContentPlanner\Service\RecordSummaryService;
+use Xima\XimaTypo3ContentPlanner\Utility\Security\PermissionUtility;
+
+use function array_map;
+use function count;
+use function is_array;
+use function is_string;
+
+/**
+ * ApiController.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+class ApiController
+{
+    /**
+     * Guards against a consumer asking for an unbounded number of records in one call.
+     * A page's worth of content elements stays far below this.
+     */
+    private const MAX_ITEMS = 500;
+
+    public function __construct(private readonly RecordSummaryService $recordSummaryService) {}
+
+    /**
+     * Returns status, assignee and comment counters for many records in one request.
+     *
+     * The route is only registered while the frontend API is enabled, so reaching this
+     * action already implies the feature flag, a backend session and a valid route token.
+     */
+    public function summaryAction(ServerRequestInterface $request): ResponseInterface
+    {
+        if (!PermissionUtility::checkContentStatusVisibility()) {
+            return new JsonResponse(['error' => 'Content planner is not visible for this user'], 403);
+        }
+
+        $items = $this->parseItems($request);
+        if (null === $items) {
+            return new JsonResponse(['error' => 'Expected a JSON body of shape {"items":[{"table":"…","uid":1}]}'], 400);
+        }
+
+        if (count($items) > self::MAX_ITEMS) {
+            return new JsonResponse(['error' => 'Too many items, at most '.self::MAX_ITEMS.' per request'], 400);
+        }
+
+        $summaries = $this->recordSummaryService->buildForItems($items);
+
+        return new JsonResponse([
+            'items' => array_map(static fn (RecordSummary $summary): array => $summary->toArray(), $summaries),
+        ]);
+    }
+
+    /**
+     * @return array<int, array{table: string, uid: int}>|null null when the payload is unusable
+     */
+    private function parseItems(ServerRequestInterface $request): ?array
+    {
+        $body = $request->getParsedBody();
+
+        // Backend AJAX routes only decode form-encoded bodies, so a JSON content type
+        // arrives as a raw stream and has to be decoded here.
+        if (!is_array($body)) {
+            $decoded = json_decode((string) $request->getBody(), true);
+            $body = is_array($decoded) ? $decoded : null;
+        }
+
+        if (null === $body || !isset($body['items']) || !is_array($body['items'])) {
+            return null;
+        }
+
+        $items = [];
+        foreach ($body['items'] as $item) {
+            if (!is_array($item) || !isset($item['table'], $item['uid']) || !is_string($item['table'])) {
+                continue;
+            }
+
+            $items[] = ['table' => $item['table'], 'uid' => (int) $item['uid']];
+        }
+
+        return $items;
+    }
+}

--- a/Classes/Controller/ApiController.php
+++ b/Classes/Controller/ApiController.php
@@ -52,16 +52,19 @@ class ApiController
             return new JsonResponse(['error' => 'Content planner is not visible for this user'], 403);
         }
 
-        $items = $this->parseItems($request);
-        if (null === $items) {
+        $rawItems = $this->readItemList($request);
+        if (null === $rawItems) {
             return new JsonResponse(['error' => 'Expected a JSON body of shape {"items":[{"table":"…","uid":1}]}'], 400);
         }
 
-        if (count($items) > self::MAX_ITEMS) {
+        // Counted before normalizing: malformed entries are dropped there, so counting
+        // afterwards would let an oversized batch of them slip through and answer 200
+        // with an empty list instead of rejecting the request.
+        if (count($rawItems) > self::MAX_ITEMS) {
             return new JsonResponse(['error' => 'Too many items, at most '.self::MAX_ITEMS.' per request'], 400);
         }
 
-        $summaries = $this->recordSummaryService->buildForItems($items);
+        $summaries = $this->recordSummaryService->buildForItems($this->normalizeItems($rawItems));
 
         return new JsonResponse([
             'items' => array_map(static fn (RecordSummary $summary): array => $summary->toArray(), $summaries),
@@ -69,9 +72,9 @@ class ApiController
     }
 
     /**
-     * @return array<int, array{table: string, uid: int}>|null null when the payload is unusable
+     * @return array<int, mixed>|null the raw item list, or null when the payload is unusable
      */
-    private function parseItems(ServerRequestInterface $request): ?array
+    private function readItemList(ServerRequestInterface $request): ?array
     {
         $body = $request->getParsedBody();
 
@@ -86,8 +89,21 @@ class ApiController
             return null;
         }
 
+        return array_values($body['items']);
+    }
+
+    /**
+     * Drops entries that cannot address a record. Silent, because a consumer batching a
+     * page's elements should not lose the whole response over one bad entry.
+     *
+     * @param array<int, mixed> $rawItems
+     *
+     * @return array<int, array{table: string, uid: int}>
+     */
+    private function normalizeItems(array $rawItems): array
+    {
         $items = [];
-        foreach ($body['items'] as $item) {
+        foreach ($rawItems as $item) {
             if (!is_array($item) || !isset($item['table'], $item['uid']) || !is_string($item['table'])) {
                 continue;
             }

--- a/Classes/Domain/Model/Dto/Summary/AssigneeSummary.php
+++ b/Classes/Domain/Model/Dto/Summary/AssigneeSummary.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Domain\Model\Dto\Summary;
+
+/**
+ * AssigneeSummary.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final readonly class AssigneeSummary
+{
+    public function __construct(
+        public int $uid,
+        public string $displayName,
+    ) {}
+
+    /**
+     * @return array{uid: int, displayName: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'uid' => $this->uid,
+            'displayName' => $this->displayName,
+        ];
+    }
+}

--- a/Classes/Domain/Model/Dto/Summary/CapabilitySummary.php
+++ b/Classes/Domain/Model/Dto/Summary/CapabilitySummary.php
@@ -25,16 +25,20 @@ final readonly class CapabilitySummary
      * What the current backend user may do with this record. Advisory only — a consumer
      * hiding a button is a convenience, never the enforcement, which happens again in
      * every write endpoint.
+     *
+     * There is deliberately no "may view comments" flag: the extension has no such
+     * permission, so it could only ever be true, and a field that never varies suggests
+     * a check that does not exist. Being able to read a record's comments follows from
+     * the visibility check already applied to the whole request.
      */
     public function __construct(
         public bool $canChangeStatus,
         public bool $canUnsetStatus,
         public bool $canComment,
-        public bool $canViewComments,
     ) {}
 
     /**
-     * @return array{canChangeStatus: bool, canUnsetStatus: bool, canComment: bool, canViewComments: bool}
+     * @return array{canChangeStatus: bool, canUnsetStatus: bool, canComment: bool}
      */
     public function toArray(): array
     {
@@ -42,7 +46,6 @@ final readonly class CapabilitySummary
             'canChangeStatus' => $this->canChangeStatus,
             'canUnsetStatus' => $this->canUnsetStatus,
             'canComment' => $this->canComment,
-            'canViewComments' => $this->canViewComments,
         ];
     }
 }

--- a/Classes/Domain/Model/Dto/Summary/CapabilitySummary.php
+++ b/Classes/Domain/Model/Dto/Summary/CapabilitySummary.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Domain\Model\Dto\Summary;
+
+/**
+ * CapabilitySummary.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final readonly class CapabilitySummary
+{
+    /**
+     * What the current backend user may do with this record. Advisory only — a consumer
+     * hiding a button is a convenience, never the enforcement, which happens again in
+     * every write endpoint.
+     */
+    public function __construct(
+        public bool $canChangeStatus,
+        public bool $canUnsetStatus,
+        public bool $canComment,
+        public bool $canViewComments,
+    ) {}
+
+    /**
+     * @return array{canChangeStatus: bool, canUnsetStatus: bool, canComment: bool, canViewComments: bool}
+     */
+    public function toArray(): array
+    {
+        return [
+            'canChangeStatus' => $this->canChangeStatus,
+            'canUnsetStatus' => $this->canUnsetStatus,
+            'canComment' => $this->canComment,
+            'canViewComments' => $this->canViewComments,
+        ];
+    }
+}

--- a/Classes/Domain/Model/Dto/Summary/CommentSummary.php
+++ b/Classes/Domain/Model/Dto/Summary/CommentSummary.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Domain\Model\Dto\Summary;
+
+/**
+ * CommentSummary.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final readonly class CommentSummary
+{
+    /**
+     * $total counts open comments including replies, matching the backend badge, which
+     * uses CommentRepository::countAllByRecord() with its defaults.
+     */
+    public function __construct(
+        public int $total,
+        public int $todoTotal,
+        public int $todoResolved,
+    ) {}
+
+    /**
+     * @return array{total: int, todoTotal: int, todoResolved: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'total' => $this->total,
+            'todoTotal' => $this->todoTotal,
+            'todoResolved' => $this->todoResolved,
+        ];
+    }
+}

--- a/Classes/Domain/Model/Dto/Summary/RecordSummary.php
+++ b/Classes/Domain/Model/Dto/Summary/RecordSummary.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Domain\Model\Dto\Summary;
+
+/**
+ * RecordSummary.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final readonly class RecordSummary
+{
+    public function __construct(
+        public string $table,
+        public int $uid,
+        public ?StatusSummary $status,
+        public ?AssigneeSummary $assignee,
+        public CommentSummary $comments,
+        public CapabilitySummary $capabilities,
+    ) {}
+
+    /**
+     * The API's per-record shape. Kept free of rendered markup on purpose — StatusItem
+     * remains the HTML-bearing DTO for the backend views.
+     *
+     * @return array{
+     *     table: string,
+     *     uid: int,
+     *     status: array{uid: int, title: string, colorName: string, colorHex: string|null, iconIdentifier: string}|null,
+     *     assignee: array{uid: int, displayName: string}|null,
+     *     comments: array{total: int, todoTotal: int, todoResolved: int},
+     *     capabilities: array{canChangeStatus: bool, canUnsetStatus: bool, canComment: bool, canViewComments: bool}
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'table' => $this->table,
+            'uid' => $this->uid,
+            'status' => $this->status?->toArray(),
+            'assignee' => $this->assignee?->toArray(),
+            'comments' => $this->comments->toArray(),
+            'capabilities' => $this->capabilities->toArray(),
+        ];
+    }
+}

--- a/Classes/Domain/Model/Dto/Summary/RecordSummary.php
+++ b/Classes/Domain/Model/Dto/Summary/RecordSummary.php
@@ -40,7 +40,7 @@ final readonly class RecordSummary
      *     status: array{uid: int, title: string, colorName: string, colorHex: string|null, iconIdentifier: string}|null,
      *     assignee: array{uid: int, displayName: string}|null,
      *     comments: array{total: int, todoTotal: int, todoResolved: int},
-     *     capabilities: array{canChangeStatus: bool, canUnsetStatus: bool, canComment: bool, canViewComments: bool}
+     *     capabilities: array{canChangeStatus: bool, canUnsetStatus: bool, canComment: bool}
      * }
      */
     public function toArray(): array

--- a/Classes/Domain/Model/Dto/Summary/StatusSummary.php
+++ b/Classes/Domain/Model/Dto/Summary/StatusSummary.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Domain\Model\Dto\Summary;
+
+use Xima\XimaTypo3ContentPlanner\Configuration\Colors;
+use Xima\XimaTypo3ContentPlanner\Domain\Model\Status;
+
+use function in_array;
+
+/**
+ * StatusSummary.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final readonly class StatusSummary
+{
+    public function __construct(
+        public int $uid,
+        public string $title,
+        public string $colorName,
+        public ?string $colorHex,
+        public string $iconIdentifier,
+    ) {}
+
+    public static function fromStatus(Status $status): self
+    {
+        $colorName = $status->getColor();
+
+        return new self(
+            uid: (int) $status->getUid(),
+            title: $status->getTitle(),
+            colorName: $colorName,
+            // Colors::getHex() throws for anything outside its palette, and a legacy or
+            // hand-edited status record can carry an empty colour. One such record must
+            // not take down a whole batch response.
+            colorHex: in_array($colorName, Colors::STATUS_COLORS, true) ? Colors::getHex($colorName) : null,
+            // The identifier, not rendered markup — rendering is the consumer's job.
+            iconIdentifier: $status->getColoredIcon(),
+        );
+    }
+
+    /**
+     * @return array{uid: int, title: string, colorName: string, colorHex: string|null, iconIdentifier: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'uid' => $this->uid,
+            'title' => $this->title,
+            'colorName' => $this->colorName,
+            'colorHex' => $this->colorHex,
+            'iconIdentifier' => $this->iconIdentifier,
+        ];
+    }
+}

--- a/Classes/Domain/Repository/BackendUserRepository.php
+++ b/Classes/Domain/Repository/BackendUserRepository.php
@@ -159,7 +159,7 @@ class BackendUserRepository
      */
     public function getDisplayNamesByUids(array $uids): array
     {
-        $uids = array_values(array_filter(array_map('intval', $uids), static fn (int $uid): bool => $uid > 0));
+        $uids = array_values(array_filter(array_map(intval(...), $uids), static fn (int $uid): bool => $uid > 0));
         if ([] === $uids) {
             return [];
         }

--- a/Classes/Domain/Repository/BackendUserRepository.php
+++ b/Classes/Domain/Repository/BackendUserRepository.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3ContentPlanner\Domain\Repository;
 
-use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\{ArrayParameterType, Exception};
 use TYPO3\CMS\Core\Database\{Connection, ConnectionPool};
 use Xima\XimaTypo3ContentPlanner\Configuration;
 
+use function array_filter;
 use function array_key_exists;
+use function array_map;
+use function array_values;
 use function in_array;
 
 /**
@@ -141,6 +144,48 @@ class BackendUserRepository
      *
      * @throws Exception
      */
+    /**
+     * Batched display names for a set of backend users, in a single query.
+     *
+     * Unlike getUsernameByUid() the result is deliberately **not** HTML-escaped: this
+     * feeds JSON responses, where escaping is the consumer's job at render time and
+     * pre-escaping would leak entities such as "&amp;" into the payload.
+     *
+     * @param int[] $uids
+     *
+     * @return array<int, string> display name keyed by user uid; unknown uids are absent
+     *
+     * @throws Exception
+     */
+    public function getDisplayNamesByUids(array $uids): array
+    {
+        $uids = array_values(array_filter(array_map('intval', $uids), static fn (int $uid): bool => $uid > 0));
+        if ([] === $uids) {
+            return [];
+        }
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('be_users');
+        $rows = $queryBuilder
+            ->select('uid', 'username', 'realName')
+            ->from('be_users')
+            ->where(
+                $queryBuilder->expr()->in('uid', $queryBuilder->createNamedParameter($uids, ArrayParameterType::INTEGER)),
+            )
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $names = [];
+        foreach ($rows as $row) {
+            $name = (string) $row['username'];
+            if ((bool) $row['realName']) {
+                $name = $row['realName'].' ('.$name.')';
+            }
+            $names[(int) $row['uid']] = $name;
+        }
+
+        return $names;
+    }
+
     public function getUsernameByUid(?int $uid): string
     {
         if (!(bool) $uid) {

--- a/Classes/Domain/Repository/CommentRepository.php
+++ b/Classes/Domain/Repository/CommentRepository.php
@@ -156,7 +156,7 @@ class CommentRepository
      */
     public function countAllByRecords(string $table, array $uids): array
     {
-        $counts = array_fill_keys(array_map('intval', $uids), 0);
+        $counts = array_fill_keys(array_map(intval(...), $uids), 0);
         if ([] === $counts) {
             return [];
         }
@@ -194,7 +194,7 @@ class CommentRepository
      */
     public function countTodosByRecords(string $table, array $uids): array
     {
-        $sums = array_fill_keys(array_map('intval', $uids), ['total' => 0, 'resolved' => 0]);
+        $sums = array_fill_keys(array_map(intval(...), $uids), ['total' => 0, 'resolved' => 0]);
         if ([] === $sums) {
             return [];
         }

--- a/Classes/Domain/Repository/CommentRepository.php
+++ b/Classes/Domain/Repository/CommentRepository.php
@@ -13,13 +13,15 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3ContentPlanner\Domain\Repository;
 
-use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\{ArrayParameterType, Exception};
 use InvalidArgumentException;
 use TYPO3\CMS\Core\Database\{Connection, ConnectionPool};
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use Xima\XimaTypo3ContentPlanner\Configuration;
 use Xima\XimaTypo3ContentPlanner\Domain\Model\Dto\CommentItem;
 
+use function array_fill_keys;
+use function array_keys;
 use function array_map;
 use function count;
 use function in_array;
@@ -139,6 +141,90 @@ class CommentRepository
         }
 
         return $query->executeQuery()->fetchOne();
+    }
+
+    /**
+     * Batched counterpart of countAllByRecord() for a set of records of one table, so a
+     * whole page worth of elements costs a single query instead of one per element.
+     *
+     * @param int[] $uids
+     *
+     * @return array<int, int> open comment count keyed by record uid, zero-filled for
+     *                         records without comments
+     *
+     * @throws Exception
+     */
+    public function countAllByRecords(string $table, array $uids): array
+    {
+        $counts = array_fill_keys(array_map('intval', $uids), 0);
+        if ([] === $counts) {
+            return [];
+        }
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $rows = $queryBuilder
+            ->selectLiteral('`foreign_uid`', 'COUNT(`uid`) AS `count`')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->in('foreign_uid', $queryBuilder->createNamedParameter(array_keys($counts), ArrayParameterType::INTEGER)),
+                $queryBuilder->expr()->eq('foreign_table', $queryBuilder->createNamedParameter($table, Connection::PARAM_STR)),
+                $queryBuilder->expr()->eq('deleted', 0),
+                $queryBuilder->expr()->eq('resolved_date', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+            )
+            ->groupBy('foreign_uid')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        foreach ($rows as $row) {
+            $counts[(int) $row['foreign_uid']] = (int) $row['count'];
+        }
+
+        return $counts;
+    }
+
+    /**
+     * Batched counterpart of countTodosByRecord().
+     *
+     * @param int[] $uids
+     *
+     * @return array<int, array{total: int, resolved: int}> keyed by record uid,
+     *                                                      zero-filled for records without to-dos
+     *
+     * @throws Exception
+     */
+    public function countTodosByRecords(string $table, array $uids): array
+    {
+        $sums = array_fill_keys(array_map('intval', $uids), ['total' => 0, 'resolved' => 0]);
+        if ([] === $sums) {
+            return [];
+        }
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $rows = $queryBuilder
+            ->selectLiteral(
+                '`foreign_uid`',
+                'COALESCE(SUM(`todo_total`), 0) AS `total`',
+                'COALESCE(SUM(`todo_resolved`), 0) AS `resolved`',
+            )
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->in('foreign_uid', $queryBuilder->createNamedParameter(array_keys($sums), ArrayParameterType::INTEGER)),
+                $queryBuilder->expr()->eq('foreign_table', $queryBuilder->createNamedParameter($table, Connection::PARAM_STR)),
+                $queryBuilder->expr()->eq('deleted', 0),
+                $queryBuilder->expr()->eq('resolved_date', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+            )
+            ->groupBy('foreign_uid')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        foreach ($rows as $row) {
+            $sums[(int) $row['foreign_uid']] = [
+                'total' => (int) $row['total'],
+                'resolved' => (int) $row['resolved'],
+            ];
+        }
+
+        return $sums;
     }
 
     public function countTodoAllByRecord(?int $id = null, ?string $table = null, string $todoField = 'todo_resolved', bool $allRecords = false): int

--- a/Classes/Domain/Repository/RecordRepository.php
+++ b/Classes/Domain/Repository/RecordRepository.php
@@ -197,7 +197,7 @@ class RecordRepository
      */
     public function findAllByUids(string $table, array $uids, bool $ignoreVisibilityRestriction = false): array
     {
-        $uids = array_values(array_unique(array_map('intval', $uids)));
+        $uids = array_values(array_unique(array_map(intval(...), $uids)));
 
         // Same whitelist as findByUid(): the table name reaches getQueryBuilderForTable()
         // and getTitleField() straight from request input.

--- a/Classes/Domain/Repository/RecordRepository.php
+++ b/Classes/Domain/Repository/RecordRepository.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3ContentPlanner\Domain\Repository;
 
-use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\{ArrayParameterType, Exception};
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 use TYPO3\CMS\Core\Database\{Connection, ConnectionPool};
 use TYPO3\CMS\Core\Database\Query\Restriction\{EndTimeRestriction, HiddenRestriction, StartTimeRestriction};
@@ -23,6 +23,9 @@ use Xima\XimaTypo3ContentPlanner\Configuration;
 use Xima\XimaTypo3ContentPlanner\Utility\ExtensionUtility;
 use Xima\XimaTypo3ContentPlanner\Utility\Security\PermissionUtility;
 
+use function array_map;
+use function array_unique;
+use function array_values;
 use function count;
 use function in_array;
 use function is_array;
@@ -168,14 +171,38 @@ class RecordRepository
      */
     public function findByUid(?string $table, ?int $uid, bool $ignoreVisibilityRestriction = false): array|bool|null
     {
-        if (!(bool) $table && !(bool) $uid) {
+        // Only registered content planner record tables may be queried through this method
+        // (the table name flows into getQueryBuilderForTable()/getTitleField() from request input).
+        // A null or empty table name never passes this, which also covers the "no arguments
+        // at all" case.
+        if (null === $table || !in_array($table, ExtensionUtility::getRecordTables(), true)) {
             return null;
         }
 
-        // Only registered content planner record tables may be queried through this method
-        // (the table name flows into getQueryBuilderForTable()/getTitleField() from request input).
-        if (null === $table || !in_array($table, ExtensionUtility::getRecordTables(), true)) {
-            return null;
+        // Delegates to the batched variant so both paths share one query definition;
+        // returns false for a missing record, matching fetchAssociative().
+        return $this->findAllByUids($table, [(int) $uid], $ignoreVisibilityRestriction)[(int) $uid] ?? false;
+    }
+
+    /**
+     * Batched counterpart of findByUid() for a set of records of one table, so a whole
+     * page worth of elements costs a single query instead of one per element.
+     *
+     * @param int[] $uids
+     *
+     * @return array<int, array<string, mixed>> found records keyed by uid; uids that do
+     *                                          not exist are simply absent
+     *
+     * @throws Exception
+     */
+    public function findAllByUids(string $table, array $uids, bool $ignoreVisibilityRestriction = false): array
+    {
+        $uids = array_values(array_unique(array_map('intval', $uids)));
+
+        // Same whitelist as findByUid(): the table name reaches getQueryBuilderForTable()
+        // and getTitleField() straight from request input.
+        if ([] === $uids || !in_array($table, ExtensionUtility::getRecordTables(), true)) {
+            return [];
         }
 
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
@@ -190,15 +217,19 @@ class RecordRepository
             ->select('uid', 'pid', $this->getTitleField($table).' as "title"', Configuration::FIELD_STATUS, Configuration::FIELD_ASSIGNEE, Configuration::FIELD_COMMENTS)
             ->from($table)
             ->andWhere(
-                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)),
+                $queryBuilder->expr()->in('uid', $queryBuilder->createNamedParameter($uids, ArrayParameterType::INTEGER)),
             );
 
         if ($this->hasDeletedRestriction($table)) {
             $query->andWhere($queryBuilder->expr()->eq('deleted', 0));
         }
 
-        return $query->executeQuery()
-            ->fetchAssociative();
+        $records = [];
+        foreach ($query->executeQuery()->fetchAllAssociative() as $record) {
+            $records[(int) $record['uid']] = $record;
+        }
+
+        return $records;
     }
 
     public function updateStatusByUid(string $table, int $uid, ?int $status, int|bool|null $assignee = false): void

--- a/Classes/Service/RecordSummaryService.php
+++ b/Classes/Service/RecordSummaryService.php
@@ -262,6 +262,6 @@ class RecordSummaryService
             $grouped[$table][$uid] = $uid;
         }
 
-        return array_map('array_values', $grouped);
+        return array_map(array_values(...), $grouped);
     }
 }

--- a/Classes/Service/RecordSummaryService.php
+++ b/Classes/Service/RecordSummaryService.php
@@ -113,9 +113,6 @@ class RecordSummaryService
             canChangeStatus: PermissionUtility::canChangeStatus(0 !== $statusUid ? $statusUid : null),
             canUnsetStatus: PermissionUtility::canUnsetStatus(),
             canComment: PermissionUtility::canCreateComment(),
-            // There is no dedicated view permission; seeing comments follows from the
-            // visibility check already applied to the whole request.
-            canViewComments: true,
         );
     }
 

--- a/Classes/Service/RecordSummaryService.php
+++ b/Classes/Service/RecordSummaryService.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Service;
+
+use Doctrine\DBAL\Exception;
+use Xima\XimaTypo3ContentPlanner\Configuration;
+use Xima\XimaTypo3ContentPlanner\Domain\Model\Dto\Summary\{AssigneeSummary, CapabilitySummary, CommentSummary, RecordSummary, StatusSummary};
+use Xima\XimaTypo3ContentPlanner\Domain\Model\Status;
+use Xima\XimaTypo3ContentPlanner\Domain\Repository\{BackendUserRepository, CommentRepository, RecordRepository};
+use Xima\XimaTypo3ContentPlanner\Utility\Data\ContentUtility;
+use Xima\XimaTypo3ContentPlanner\Utility\ExtensionUtility;
+use Xima\XimaTypo3ContentPlanner\Utility\Security\PermissionUtility;
+
+use function array_key_exists;
+use function array_keys;
+use function array_map;
+use function array_values;
+
+/**
+ * RecordSummaryService.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+class RecordSummaryService
+{
+    /** @var array<int, Status|null> */
+    private array $statusCache = [];
+
+    public function __construct(
+        private readonly RecordRepository $recordRepository,
+        private readonly CommentRepository $commentRepository,
+        private readonly BackendUserRepository $backendUserRepository,
+    ) {}
+
+    /**
+     * Builds a summary per requested record, batching every lookup so the cost is a
+     * handful of queries per table rather than a handful per record.
+     *
+     * Records the current user may not see are omitted rather than reported as an error,
+     * so one forbidden element cannot spoil a whole page's request.
+     *
+     * @param array<int, array{table: string, uid: int}> $items
+     *
+     * @return RecordSummary[]
+     *
+     * @throws Exception
+     */
+    public function buildForItems(array $items): array
+    {
+        if (!$this->isVisible()) {
+            return [];
+        }
+
+        $summaries = [];
+        foreach ($this->groupUidsByTable($items) as $table => $uids) {
+            foreach ($this->buildForTable($table, $uids) as $summary) {
+                $summaries[] = $summary;
+            }
+        }
+
+        return $summaries;
+    }
+
+    /*
+     * Everything that reads global TYPO3 state — permissions and extension
+     * configuration — sits behind these seams, so the batching behaviour can be
+     * exercised without a backend user session or a booted extension configuration.
+     */
+
+    protected function areTodosEnabled(): bool
+    {
+        return ExtensionUtility::isFeatureEnabled(Configuration::FEATURE_COMMENT_TODOS);
+    }
+
+    protected function isVisible(): bool
+    {
+        return PermissionUtility::checkContentStatusVisibility();
+    }
+
+    protected function isTableUsable(string $table): bool
+    {
+        return ExtensionUtility::isRegisteredRecordTable($table) && PermissionUtility::isTableAllowedForUser($table);
+    }
+
+    /**
+     * @param array<string, mixed> $record
+     */
+    protected function isRecordAccessible(string $table, array $record): bool
+    {
+        return PermissionUtility::checkAccessForRecord($table, $record);
+    }
+
+    /**
+     * @param array<string, mixed> $record
+     */
+    protected function capabilitiesFor(array $record): CapabilitySummary
+    {
+        $statusUid = (int) ($record[Configuration::FIELD_STATUS] ?? 0);
+
+        return new CapabilitySummary(
+            canChangeStatus: PermissionUtility::canChangeStatus(0 !== $statusUid ? $statusUid : null),
+            canUnsetStatus: PermissionUtility::canUnsetStatus(),
+            canComment: PermissionUtility::canCreateComment(),
+            // There is no dedicated view permission; seeing comments follows from the
+            // visibility check already applied to the whole request.
+            canViewComments: true,
+        );
+    }
+
+    /**
+     * @param int[] $uids
+     *
+     * @return RecordSummary[]
+     *
+     * @throws Exception
+     */
+    private function buildForTable(string $table, array $uids): array
+    {
+        // findAllByUids() whitelists the table itself, but bailing out early also skips
+        // the comment and assignee queries for a table this user may not read at all.
+        if (!$this->isTableUsable($table)) {
+            return [];
+        }
+
+        $records = $this->recordRepository->findAllByUids($table, $uids, ignoreVisibilityRestriction: true);
+        if ([] === $records) {
+            return [];
+        }
+
+        $accessible = [];
+        foreach ($records as $uid => $record) {
+            if ($this->isRecordAccessible($table, $record)) {
+                $accessible[$uid] = $record;
+            }
+        }
+
+        if ([] === $accessible) {
+            return [];
+        }
+
+        $accessibleUids = array_keys($accessible);
+        $commentCounts = $this->commentRepository->countAllByRecords($table, $accessibleUids);
+        $todoCounts = $this->todoCountsFor($table, $accessibleUids);
+        $assigneeNames = $this->assigneeNamesFor($accessible);
+
+        $summaries = [];
+        foreach ($accessible as $uid => $record) {
+            $summaries[] = new RecordSummary(
+                table: $table,
+                uid: $uid,
+                status: $this->statusSummaryFor($record),
+                assignee: $this->assigneeSummaryFor($record, $assigneeNames),
+                comments: new CommentSummary(
+                    total: $commentCounts[$uid] ?? 0,
+                    todoTotal: $todoCounts[$uid]['total'] ?? 0,
+                    todoResolved: $todoCounts[$uid]['resolved'] ?? 0,
+                ),
+                capabilities: $this->capabilitiesFor($record),
+            );
+        }
+
+        return $summaries;
+    }
+
+    /**
+     * @param int[] $uids
+     *
+     * @return array<int, array{total: int, resolved: int}>
+     *
+     * @throws Exception
+     */
+    private function todoCountsFor(string $table, array $uids): array
+    {
+        // Mirrors StatusItem, which reports no to-dos at all while the feature is off.
+        if (!$this->areTodosEnabled()) {
+            return [];
+        }
+
+        return $this->commentRepository->countTodosByRecords($table, $uids);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $records
+     *
+     * @return array<int, string>
+     *
+     * @throws Exception
+     */
+    private function assigneeNamesFor(array $records): array
+    {
+        $assigneeUids = [];
+        foreach ($records as $record) {
+            $assigneeUid = (int) ($record[Configuration::FIELD_ASSIGNEE] ?? 0);
+            if (0 !== $assigneeUid) {
+                $assigneeUids[$assigneeUid] = $assigneeUid;
+            }
+        }
+
+        return [] === $assigneeUids ? [] : $this->backendUserRepository->getDisplayNamesByUids(array_values($assigneeUids));
+    }
+
+    /**
+     * @param array<string, mixed> $record
+     */
+    private function statusSummaryFor(array $record): ?StatusSummary
+    {
+        $statusUid = (int) ($record[Configuration::FIELD_STATUS] ?? 0);
+        if (0 === $statusUid) {
+            return null;
+        }
+
+        $status = $this->resolveStatus($statusUid);
+
+        return $status instanceof Status ? StatusSummary::fromStatus($status) : null;
+    }
+
+    /**
+     * @param array<string, mixed> $record
+     * @param array<int, string>   $assigneeNames
+     */
+    private function assigneeSummaryFor(array $record, array $assigneeNames): ?AssigneeSummary
+    {
+        $assigneeUid = (int) ($record[Configuration::FIELD_ASSIGNEE] ?? 0);
+        if (0 === $assigneeUid || !array_key_exists($assigneeUid, $assigneeNames)) {
+            return null;
+        }
+
+        return new AssigneeSummary(uid: $assigneeUid, displayName: $assigneeNames[$assigneeUid]);
+    }
+
+    private function resolveStatus(int $statusUid): ?Status
+    {
+        return $this->statusCache[$statusUid] ??= ContentUtility::getStatus($statusUid);
+    }
+
+    /**
+     * @param array<int, array{table: string, uid: int}> $items
+     *
+     * @return array<string, int[]>
+     */
+    private function groupUidsByTable(array $items): array
+    {
+        $grouped = [];
+        foreach ($items as $item) {
+            $table = $item['table'];
+            $uid = $item['uid'];
+            if ('' === $table || $uid <= 0) {
+                continue;
+            }
+            $grouped[$table][$uid] = $uid;
+        }
+
+        return array_map('array_values', $grouped);
+    }
+}

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -39,7 +39,10 @@ $routes = [
 ];
 
 // The frontend API endpoints are not registered at all while the feature flag is off, so
-// core answers them with a plain 404 and no guard is needed in the actions themselves.
+// no guard is needed in the actions themselves. Verified in a 13.4 backend: an
+// unregistered backend route is answered with a redirect to the backend shell, i.e. a
+// consumer sees a 200 with an HTML document rather than a JSON error — the same shape it
+// already gets when a session expires, so it has to check the content type either way.
 // The flag only governs availability: these stay backend routes requiring a backend
 // session and a CSRF route token.
 if (Xima\XimaTypo3ContentPlanner\Utility\ExtensionUtility::isFrontendApiEnabled()) {

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-return [
+$routes = [
     'ximatypo3contentplanner_filterrecords' => [
         'path' => '/content-planner/records',
         'target' => Xima\XimaTypo3ContentPlanner\Controller\RecordController::class.'::filterAction',
@@ -37,3 +37,17 @@ return [
         'target' => Xima\XimaTypo3ContentPlanner\Controller\ProxyController::class.'::closeDocumentAction',
     ],
 ];
+
+// The frontend API endpoints are not registered at all while the feature flag is off, so
+// core answers them with a plain 404 and no guard is needed in the actions themselves.
+// The flag only governs availability: these stay backend routes requiring a backend
+// session and a CSRF route token.
+if (Xima\XimaTypo3ContentPlanner\Utility\ExtensionUtility::isFrontendApiEnabled()) {
+    $routes['ximatypo3contentplanner_api_summary'] = [
+        'path' => '/content-planner/api/summary',
+        'methods' => ['POST'],
+        'target' => Xima\XimaTypo3ContentPlanner\Controller\ApiController::class.'::summaryAction',
+    ];
+}
+
+return $routes;

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -42,6 +42,10 @@ services:
       $cache: '@cache.ximatypo3contentplanner_cache'
       $statusChangeManager: '@Xima\XimaTypo3ContentPlanner\Manager\StatusChangeManager'
 
+  # Resolved by the backend route dispatcher, not through constructor injection
+  Xima\XimaTypo3ContentPlanner\Controller\ApiController:
+    public: true
+
   Xima\XimaTypo3ContentPlanner\Service\Header\InfoGenerator:
     public: true
 

--- a/Documentation/DeveloperCorner/FrontendApi.rst
+++ b/Documentation/DeveloperCorner/FrontendApi.rst
@@ -92,7 +92,7 @@ not exist in the route collection at all.
 
     ..  code-block:: js
 
-        const response = await fetch(url, { … });
+        const response = await fetch(url);
         if (!response.headers.get('content-type')?.includes('application/json')) {
             // endpoint disabled, or the backend session is gone
         }

--- a/Documentation/DeveloperCorner/FrontendApi.rst
+++ b/Documentation/DeveloperCorner/FrontendApi.rst
@@ -78,6 +78,93 @@ Endpoints
     Endpoint contracts are documented alongside their implementation. This
     section grows as the individual endpoints land.
 
+Routes are registered only while their flag is on, so a disabled endpoint does
+not exist in the route collection at all and TYPO3 answers it with a plain 404.
+
+..  _frontend-api-summary:
+
+Annotation summary
+------------------
+
+..  code-block:: none
+
+    POST /content-planner/api/summary
+
+Returns status, assignee and comment counters for many records in **one**
+request — the call a consumer needs to render badges for a whole page: the
+``pages`` record plus all of its content elements.
+
+Request body:
+
+..  code-block:: json
+
+    {
+      "items": [
+        { "table": "pages", "uid": 12 },
+        { "table": "tt_content", "uid": 34 }
+      ]
+    }
+
+Response:
+
+..  code-block:: json
+
+    {
+      "items": [
+        {
+          "table": "pages",
+          "uid": 12,
+          "status": {
+            "uid": 2,
+            "title": "In Progress",
+            "colorName": "yellow",
+            "colorHex": "#ffcd75",
+            "iconIdentifier": "flag-yellow"
+          },
+          "assignee": { "uid": 3, "displayName": "Jane Doe (jane)" },
+          "comments": { "total": 2, "todoTotal": 3, "todoResolved": 1 },
+          "capabilities": {
+            "canChangeStatus": true,
+            "canUnsetStatus": true,
+            "canComment": true,
+            "canViewComments": true
+          }
+        }
+      ]
+    }
+
+``status`` and ``assignee`` are ``null`` when the record carries none, which is
+cheap for a consumer to skip.
+
+Contract notes:
+
+No markup
+    The response never contains rendered HTML or pre-escaped entities. Icons are
+    reported as **identifiers** and colours as hex values; rendering and escaping
+    are the consumer's job. The backend keeps its own HTML-bearing DTO
+    (``StatusItem``), which is deliberately left untouched.
+
+Silent omission
+    Records the current user may not see — a table they lack access to, a page
+    outside their mounts, a uid that does not exist — are **left out** of
+    ``items`` rather than reported as an error, so one forbidden element cannot
+    spoil a whole page's request. Consumers must not assume the response has the
+    same length or order as the request; match on ``table`` plus ``uid``.
+
+Counter semantics
+    ``comments.total`` counts *open* comments including replies, exactly like the
+    backend badge. To-do counters are zero while
+    :ref:`commentTodos <extconf-commentTodos>` is off, again matching the
+    backend.
+
+Batch limit
+    At most 500 items per request; a larger batch is rejected with 400. A page's
+    worth of content elements stays far below that.
+
+Capabilities
+    Advisory, for hiding controls a user cannot use. They are never the
+    enforcement — every write endpoint re-checks permissions itself.
+
 Checking a flag
 ===============
 

--- a/Documentation/DeveloperCorner/FrontendApi.rst
+++ b/Documentation/DeveloperCorner/FrontendApi.rst
@@ -79,7 +79,23 @@ Endpoints
     section grows as the individual endpoints land.
 
 Routes are registered only while their flag is on, so a disabled endpoint does
-not exist in the route collection at all and TYPO3 answers it with a plain 404.
+not exist in the route collection at all.
+
+..  warning::
+    A request to an unregistered backend route is **not** answered with a 404.
+    TYPO3 redirects it to the backend shell, so a consumer receives a ``200``
+    carrying an HTML document instead of JSON.
+
+    This is the same response shape a consumer already gets when the backend
+    session has expired, so it has to verify the response content type rather
+    than trust the status code:
+
+    ..  code-block:: js
+
+        const response = await fetch(url, { … });
+        if (!response.headers.get('content-type')?.includes('application/json')) {
+            // endpoint disabled, or the backend session is gone
+        }
 
 ..  _frontend-api-summary:
 

--- a/Documentation/DeveloperCorner/FrontendApi.rst
+++ b/Documentation/DeveloperCorner/FrontendApi.rst
@@ -142,8 +142,7 @@ Response:
           "capabilities": {
             "canChangeStatus": true,
             "canUnsetStatus": true,
-            "canComment": true,
-            "canViewComments": true
+            "canComment": true
           }
         }
       ]
@@ -180,6 +179,12 @@ Batch limit
 Capabilities
     Advisory, for hiding controls a user cannot use. They are never the
     enforcement — every write endpoint re-checks permissions itself.
+
+    There is no "may view comments" flag on purpose: the extension has no such
+    permission, so it could only ever be ``true``, and a field that never varies
+    suggests a check that does not exist. Being able to read a record's comments
+    follows from the visibility check applied to the whole request — if a record
+    appears in ``items`` at all, its comments are readable.
 
 Checking a flag
 ===============

--- a/Tests/Functional/Controller/ApiControllerTest.php
+++ b/Tests/Functional/Controller/ApiControllerTest.php
@@ -136,6 +136,19 @@ final class ApiControllerTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function rejectsAnOversizedBatchOfMalformedItems(): void
+    {
+        // The limit is counted on the raw list. Counting after normalization would drop
+        // these entries first and answer 200 with an empty list.
+        $items = array_fill(0, 501, 'not-an-item');
+
+        $response = $this->subject->summaryAction($this->requestWithBody(['items' => $items]));
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertStringContainsString('Too many items', (string) $response->getBody());
+    }
+
+    #[Test]
     public function skipsMalformedItemEntries(): void
     {
         $response = $this->subject->summaryAction($this->requestWithBody([

--- a/Tests/Functional/Controller/ApiControllerTest.php
+++ b/Tests/Functional/Controller/ApiControllerTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Tests\Functional\Controller;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Http\{ServerRequest, StreamFactory};
+use Xima\XimaTypo3ContentPlanner\Configuration;
+use Xima\XimaTypo3ContentPlanner\Controller\ApiController;
+use Xima\XimaTypo3ContentPlanner\Tests\Functional\AbstractFunctionalTestCase;
+
+use function dirname;
+
+/**
+ * ApiControllerTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class ApiControllerTest extends AbstractFunctionalTestCase
+{
+    private ApiController $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importSharedDataSet('status.csv');
+        $this->importCSVDataSet(__DIR__.'/../Service/Fixtures/summary_pages.csv');
+        $this->importCSVDataSet(__DIR__.'/../Service/Fixtures/summary_comments.csv');
+        $this->loginBackendUser();
+        $this->setUpBackendRequest();
+        $this->subject = $this->get(ApiController::class);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY][Configuration::FEATURE_FRONTEND_API]);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function theRouteIsNotRegisteredWhileTheFlagIsOff(): void
+    {
+        self::assertArrayNotHasKey('ximatypo3contentplanner_api_summary', $this->loadAjaxRoutes());
+    }
+
+    #[Test]
+    public function theRouteIsRegisteredAsAPostRouteOnceTheFlagIsOn(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY][Configuration::FEATURE_FRONTEND_API] = 1;
+
+        $routes = $this->loadAjaxRoutes();
+
+        self::assertArrayHasKey('ximatypo3contentplanner_api_summary', $routes);
+        self::assertSame('/content-planner/api/summary', $routes['ximatypo3contentplanner_api_summary']['path']);
+        self::assertSame(['POST'], $routes['ximatypo3contentplanner_api_summary']['methods']);
+    }
+
+    #[Test]
+    public function returnsASummaryPerRequestedRecord(): void
+    {
+        $response = $this->subject->summaryAction($this->requestWithBody([
+            'items' => [
+                ['table' => 'pages', 'uid' => 1],
+                ['table' => 'pages', 'uid' => 3],
+            ],
+        ]));
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = json_decode((string) $response->getBody(), true);
+        self::assertCount(2, $payload['items']);
+        self::assertSame(['table', 'uid', 'status', 'assignee', 'comments', 'capabilities'], array_keys($payload['items'][0]));
+    }
+
+    #[Test]
+    public function theResponseCarriesNoHtml(): void
+    {
+        $response = $this->subject->summaryAction($this->requestWithBody([
+            'items' => [['table' => 'pages', 'uid' => 1]],
+        ]));
+
+        self::assertStringNotContainsString('<', (string) $response->getBody());
+    }
+
+    #[Test]
+    public function omitsForbiddenRecordsInsteadOfFailingTheWholeBatch(): void
+    {
+        $response = $this->subject->summaryAction($this->requestWithBody([
+            'items' => [
+                ['table' => 'pages', 'uid' => 1],
+                ['table' => 'be_users', 'uid' => 1],
+                ['table' => 'pages', 'uid' => 9999],
+            ],
+        ]));
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = json_decode((string) $response->getBody(), true);
+        self::assertCount(1, $payload['items']);
+        self::assertSame(1, $payload['items'][0]['uid']);
+    }
+
+    #[Test]
+    public function rejectsAPayloadWithoutAnItemsArray(): void
+    {
+        self::assertSame(400, $this->subject->summaryAction($this->requestWithBody(['nope' => true]))->getStatusCode());
+    }
+
+    #[Test]
+    public function rejectsAnUnparseableBody(): void
+    {
+        $request = (new ServerRequest('https://example.com/typo3/ajax/content-planner/api/summary', 'POST'))
+            ->withBody($this->get(StreamFactory::class)->createStream('not json'));
+
+        self::assertSame(400, $this->subject->summaryAction($request)->getStatusCode());
+    }
+
+    #[Test]
+    public function rejectsMoreItemsThanTheBatchLimit(): void
+    {
+        $items = [];
+        for ($uid = 1; $uid <= 501; ++$uid) {
+            $items[] = ['table' => 'pages', 'uid' => $uid];
+        }
+
+        self::assertSame(400, $this->subject->summaryAction($this->requestWithBody(['items' => $items]))->getStatusCode());
+    }
+
+    #[Test]
+    public function skipsMalformedItemEntries(): void
+    {
+        $response = $this->subject->summaryAction($this->requestWithBody([
+            'items' => [
+                'not-an-array',
+                ['uid' => 1],
+                ['table' => 'pages'],
+                ['table' => 'pages', 'uid' => 1],
+            ],
+        ]));
+
+        $payload = json_decode((string) $response->getBody(), true);
+        self::assertCount(1, $payload['items']);
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    private function requestWithBody(array $body): ServerRequest
+    {
+        return (new ServerRequest('https://example.com/typo3/ajax/content-planner/api/summary', 'POST'))
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->get(StreamFactory::class)->createStream((string) json_encode($body)));
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function loadAjaxRoutes(): array
+    {
+        return require dirname(__DIR__, 3).'/Configuration/Backend/AjaxRoutes.php';
+    }
+}

--- a/Tests/Functional/Repository/BackendUserRepositoryTest.php
+++ b/Tests/Functional/Repository/BackendUserRepositoryTest.php
@@ -149,4 +149,40 @@ final class BackendUserRepositoryTest extends AbstractFunctionalTestCase
         self::assertNotContains('disabled', $usernames);
         self::assertNotContains('deleted', $usernames);
     }
+
+    #[Test]
+    public function getDisplayNamesByUidsCombinesRealNameAndUsername(): void
+    {
+        $names = $this->subject->getDisplayNamesByUids([1]);
+
+        self::assertSame('Administrator (admin)', $names[1]);
+    }
+
+    #[Test]
+    public function getDisplayNamesByUidsOmitsUnknownUids(): void
+    {
+        self::assertSame([], $this->subject->getDisplayNamesByUids([9999]));
+    }
+
+    #[Test]
+    public function getDisplayNamesByUidsIgnoresZeroAndReturnsEmptyForNoUids(): void
+    {
+        self::assertSame([], $this->subject->getDisplayNamesByUids([0]));
+        self::assertSame([], $this->subject->getDisplayNamesByUids([]));
+    }
+
+    #[Test]
+    public function getDisplayNamesByUidsDoesNotHtmlEscape(): void
+    {
+        // getUsernameByUid() escapes for backend HTML output; this variant feeds JSON,
+        // where pre-escaping would leak entities into the payload.
+        $this->getConnectionPool()->getConnectionForTable('be_users')->update(
+            'be_users',
+            ['realName' => 'Ann & Bob'],
+            ['uid' => 1],
+        );
+
+        self::assertSame('Ann & Bob (admin)', $this->subject->getDisplayNamesByUids([1])[1]);
+        self::assertStringContainsString('&amp;', $this->subject->getUsernameByUid(1));
+    }
 }

--- a/Tests/Functional/Repository/CommentRepositoryTest.php
+++ b/Tests/Functional/Repository/CommentRepositoryTest.php
@@ -236,4 +236,73 @@ final class CommentRepositoryTest extends AbstractFunctionalTestCase
         self::assertFalse($this->subject->findByUid(1));
         self::assertIsArray($this->subject->findByUid(2));
     }
+
+    #[Test]
+    public function countAllByRecordsMatchesThePerRecordCountForEveryUid(): void
+    {
+        // The batched variant feeds API badges; drifting from countAllByRecord() would make
+        // frontend counters disagree with the backend ones.
+        $uids = [10, 20, 999];
+
+        $batched = $this->subject->countAllByRecords('pages', $uids);
+
+        foreach ($uids as $uid) {
+            self::assertSame(
+                $this->subject->countAllByRecord($uid, 'pages'),
+                $batched[$uid],
+                "count mismatch for uid $uid",
+            );
+        }
+    }
+
+    #[Test]
+    public function countAllByRecordsReturnsZeroForRecordsWithoutComments(): void
+    {
+        $batched = $this->subject->countAllByRecords('pages', [999]);
+
+        self::assertSame([999 => 0], $batched);
+    }
+
+    #[Test]
+    public function countAllByRecordsIsScopedToTheGivenTable(): void
+    {
+        self::assertSame([10 => 0], $this->subject->countAllByRecords('tt_content', [10]));
+    }
+
+    #[Test]
+    public function countAllByRecordsReturnsAnEmptyArrayForNoUids(): void
+    {
+        self::assertSame([], $this->subject->countAllByRecords('pages', []));
+    }
+
+    #[Test]
+    public function countTodosByRecordsMatchesThePerRecordSumsForEveryUid(): void
+    {
+        $uids = [10, 20, 999];
+
+        $batched = $this->subject->countTodosByRecords('pages', $uids);
+
+        foreach ($uids as $uid) {
+            self::assertSame(
+                $this->subject->countTodosByRecord($uid, 'pages'),
+                $batched[$uid],
+                "todo mismatch for uid $uid",
+            );
+        }
+    }
+
+    #[Test]
+    public function countTodosByRecordsReturnsZeroedSumsForRecordsWithoutTodos(): void
+    {
+        self::assertSame(
+            [999 => ['total' => 0, 'resolved' => 0]],
+            $this->subject->countTodosByRecords('pages', [999]),
+        );
+    }
+
+    #[Test]
+    public function countTodosByRecordsReturnsAnEmptyArrayForNoUids(): void
+    {
+        self::assertSame([], $this->subject->countTodosByRecords('pages', []));
+    }
 }

--- a/Tests/Functional/Repository/RecordRepositoryTest.php
+++ b/Tests/Functional/Repository/RecordRepositoryTest.php
@@ -197,7 +197,10 @@ final class RecordRepositoryTest extends AbstractFunctionalTestCase
     {
         $batched = $this->subject->findAllByUids('pages', [2, 1]);
 
-        self::assertSame([1, 2], array_keys($batched));
+        // Asserted as a set, not a sequence: the query has no ORDER BY, so key order is
+        // whatever the database returns — and the functional suite runs on SQLite while
+        // production runs MySQL/MariaDB.
+        self::assertEqualsCanonicalizing([1, 2], array_keys($batched));
         self::assertSame(1, (int) $batched[1]['uid']);
         self::assertSame(2, (int) $batched[2]['uid']);
     }

--- a/Tests/Functional/Repository/RecordRepositoryTest.php
+++ b/Tests/Functional/Repository/RecordRepositoryTest.php
@@ -179,4 +179,55 @@ final class RecordRepositoryTest extends AbstractFunctionalTestCase
 
     // NOTE: findAllByFilter() builds raw "(SELECT ...) UNION (SELECT ...)" SQL which is invalid
     // under SQLite (the functional test driver). It is therefore not covered here.
+
+    #[Test]
+    public function findAllByUidsMatchesFindByUidForEveryRequestedRecord(): void
+    {
+        $uids = [1, 2, 3, 4];
+
+        $batched = $this->subject->findAllByUids('pages', $uids);
+
+        foreach ($uids as $uid) {
+            self::assertSame($this->subject->findByUid('pages', $uid), $batched[$uid], "mismatch for uid $uid");
+        }
+    }
+
+    #[Test]
+    public function findAllByUidsKeysResultsByUid(): void
+    {
+        $batched = $this->subject->findAllByUids('pages', [2, 1]);
+
+        self::assertSame([1, 2], array_keys($batched));
+        self::assertSame(1, (int) $batched[1]['uid']);
+        self::assertSame(2, (int) $batched[2]['uid']);
+    }
+
+    #[Test]
+    public function findAllByUidsOmitsMissingAndDeletedRecords(): void
+    {
+        // uid 5 is flagged deleted in the fixture, uid 999 does not exist
+        $batched = $this->subject->findAllByUids('pages', [1, 5, 999]);
+
+        self::assertSame([1], array_keys($batched));
+    }
+
+    #[Test]
+    public function findAllByUidsRejectsUnregisteredTables(): void
+    {
+        // The table name flows into getQueryBuilderForTable() from request input, so it
+        // has to stay whitelisted exactly like in findByUid().
+        self::assertSame([], $this->subject->findAllByUids('be_users', [1]));
+    }
+
+    #[Test]
+    public function findAllByUidsReturnsAnEmptyArrayForNoUids(): void
+    {
+        self::assertSame([], $this->subject->findAllByUids('pages', []));
+    }
+
+    #[Test]
+    public function findAllByUidsCollapsesDuplicateUids(): void
+    {
+        self::assertSame([1], array_keys($this->subject->findAllByUids('pages', [1, 1, 1])));
+    }
 }

--- a/Tests/Functional/Service/Fixtures/summary_comments.csv
+++ b/Tests/Functional/Service/Fixtures/summary_comments.csv
@@ -1,0 +1,6 @@
+"tx_ximatypo3contentplanner_comment"
+,"uid","pid","foreign_uid","foreign_table","content","author","edited","resolved_user","resolved_date","todo_resolved","todo_total","parent_uid","crdate","deleted"
+,1,0,1,"pages","Open comment",1,0,0,0,1,3,0,1000,0
+,2,0,1,"pages","Reply",2,0,0,0,0,0,1,2000,0
+,3,0,1,"pages","Resolved comment",1,0,1,5000,0,0,0,500,0
+,4,0,1,"pages","Deleted comment",1,0,0,0,0,0,0,1500,1

--- a/Tests/Functional/Service/Fixtures/summary_pages.csv
+++ b/Tests/Functional/Service/Fixtures/summary_pages.csv
@@ -1,0 +1,5 @@
+"pages"
+,"uid","pid","title","tstamp","deleted","hidden","tx_ximatypo3contentplanner_status","tx_ximatypo3contentplanner_assignee","tx_ximatypo3contentplanner_comments","perms_userid","perms_groupid","perms_user","perms_group","perms_everybody"
+,1,0,"With status and assignee",1000,0,0,1,1,2,1,0,31,31,31
+,2,1,"With status only",2000,0,0,3,0,0,1,0,31,31,31
+,3,1,"Untouched",3000,0,0,0,0,0,1,0,31,31,31

--- a/Tests/Functional/Service/RecordSummaryServiceTest.php
+++ b/Tests/Functional/Service/RecordSummaryServiceTest.php
@@ -132,7 +132,12 @@ final class RecordSummaryServiceTest extends AbstractFunctionalTestCase
         self::assertIsBool($capabilities->canChangeStatus);
         self::assertIsBool($capabilities->canUnsetStatus);
         self::assertIsBool($capabilities->canComment);
-        self::assertTrue($capabilities->canViewComments);
+        // No "may view comments" flag — the extension has no such permission, so it could
+        // only ever be true and would imply a check that does not exist.
+        self::assertSame(
+            ['canChangeStatus', 'canUnsetStatus', 'canComment'],
+            array_keys($capabilities->toArray()),
+        );
     }
 
     private function summaryFor(int $uid): RecordSummary

--- a/Tests/Functional/Service/RecordSummaryServiceTest.php
+++ b/Tests/Functional/Service/RecordSummaryServiceTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Tests\Functional\Service;
+
+use PHPUnit\Framework\Attributes\Test;
+use Xima\XimaTypo3ContentPlanner\Domain\Model\Dto\Summary\RecordSummary;
+use Xima\XimaTypo3ContentPlanner\Service\RecordSummaryService;
+use Xima\XimaTypo3ContentPlanner\Tests\Functional\AbstractFunctionalTestCase;
+
+/**
+ * RecordSummaryServiceTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class RecordSummaryServiceTest extends AbstractFunctionalTestCase
+{
+    private RecordSummaryService $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importSharedDataSet('status.csv');
+        $this->importCSVDataSet(__DIR__.'/Fixtures/summary_pages.csv');
+        $this->importCSVDataSet(__DIR__.'/Fixtures/summary_comments.csv');
+        $this->loginBackendUser();
+        $this->setUpBackendRequest();
+        $this->subject = $this->get(RecordSummaryService::class);
+    }
+
+    #[Test]
+    public function buildsOneSummaryPerAccessibleRecord(): void
+    {
+        $summaries = $this->subject->buildForItems([
+            ['table' => 'pages', 'uid' => 1],
+            ['table' => 'pages', 'uid' => 2],
+        ]);
+
+        self::assertCount(2, $summaries);
+        self::assertContainsOnlyInstancesOf(RecordSummary::class, $summaries);
+    }
+
+    #[Test]
+    public function reportsStatusAssigneeAndCounters(): void
+    {
+        $summary = $this->summaryFor(1);
+
+        self::assertNotNull($summary->status);
+        self::assertSame('Draft', $summary->status->title);
+        self::assertNotNull($summary->assignee);
+        self::assertSame(1, $summary->assignee->uid);
+        self::assertSame(2, $summary->comments->total);
+    }
+
+    #[Test]
+    public function reportsNullStatusAndAssigneeForAnUntouchedRecord(): void
+    {
+        $summary = $this->summaryFor(3);
+
+        self::assertNull($summary->status);
+        self::assertNull($summary->assignee);
+        self::assertSame(0, $summary->comments->total);
+    }
+
+    #[Test]
+    public function serializesWithoutAnyHtmlFragment(): void
+    {
+        $payload = json_encode(array_map(
+            static fn (RecordSummary $summary): array => $summary->toArray(),
+            $this->subject->buildForItems([
+                ['table' => 'pages', 'uid' => 1],
+                ['table' => 'pages', 'uid' => 2],
+                ['table' => 'pages', 'uid' => 3],
+            ]),
+        ));
+
+        self::assertIsString($payload);
+        // The whole point of the dedicated DTO: unlike StatusItem::toArray(), nothing
+        // here may carry rendered markup or a pre-escaped entity.
+        self::assertStringNotContainsString('<', $payload);
+        self::assertStringNotContainsString('&amp;', $payload);
+        self::assertStringNotContainsString('badge', $payload);
+    }
+
+    #[Test]
+    public function exposesTheStatusColourAsAHexValueAndTheIconAsAnIdentifier(): void
+    {
+        $summary = $this->summaryFor(1);
+
+        self::assertNotNull($summary->status);
+        self::assertMatchesRegularExpression('/^#[0-9a-f]{6}$/', (string) $summary->status->colorHex);
+        self::assertStringNotContainsString('<', $summary->status->iconIdentifier);
+    }
+
+    #[Test]
+    public function omitsRecordsOfUnregisteredTables(): void
+    {
+        self::assertSame([], $this->subject->buildForItems([['table' => 'be_users', 'uid' => 1]]));
+    }
+
+    #[Test]
+    public function omitsRecordsThatDoNotExist(): void
+    {
+        self::assertSame([], $this->subject->buildForItems([['table' => 'pages', 'uid' => 9999]]));
+    }
+
+    #[Test]
+    public function ignoresMalformedItems(): void
+    {
+        self::assertSame([], $this->subject->buildForItems([
+            ['table' => '', 'uid' => 1],
+            ['table' => 'pages', 'uid' => 0],
+        ]));
+    }
+
+    #[Test]
+    public function reportsCapabilitiesForEveryRecord(): void
+    {
+        $capabilities = $this->summaryFor(1)->capabilities;
+
+        self::assertIsBool($capabilities->canChangeStatus);
+        self::assertIsBool($capabilities->canUnsetStatus);
+        self::assertIsBool($capabilities->canComment);
+        self::assertTrue($capabilities->canViewComments);
+    }
+
+    private function summaryFor(int $uid): RecordSummary
+    {
+        $summaries = $this->subject->buildForItems([['table' => 'pages', 'uid' => $uid]]);
+        self::assertCount(1, $summaries);
+
+        return $summaries[0];
+    }
+}

--- a/Tests/Unit/Service/RecordSummaryServiceBatchingTest.php
+++ b/Tests/Unit/Service/RecordSummaryServiceBatchingTest.php
@@ -83,7 +83,7 @@ final class RecordSummaryServiceBatchingTest extends TestCase
              */
             protected function capabilitiesFor(array $record): CapabilitySummary
             {
-                return new CapabilitySummary(true, true, true, true);
+                return new CapabilitySummary(true, true, true);
             }
         };
 

--- a/Tests/Unit/Service/RecordSummaryServiceBatchingTest.php
+++ b/Tests/Unit/Service/RecordSummaryServiceBatchingTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Tests\Unit\Service;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Xima\XimaTypo3ContentPlanner\Domain\Model\Dto\Summary\CapabilitySummary;
+use Xima\XimaTypo3ContentPlanner\Domain\Repository\{BackendUserRepository, CommentRepository, RecordRepository};
+use Xima\XimaTypo3ContentPlanner\Service\RecordSummaryService;
+
+/**
+ * RecordSummaryServiceBatchingTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class RecordSummaryServiceBatchingTest extends TestCase
+{
+    #[Test]
+    public function queriesEachRepositoryOnlyOncePerTableRegardlessOfBatchSize(): void
+    {
+        $records = [];
+        $items = [];
+        for ($uid = 1; $uid <= 25; ++$uid) {
+            $records[$uid] = ['uid' => $uid, 'pid' => 1, 'title' => "Page $uid"];
+            $items[] = ['table' => 'pages', 'uid' => $uid];
+        }
+
+        $recordRepository = $this->createMock(RecordRepository::class);
+        $recordRepository->expects(self::once())
+            ->method('findAllByUids')
+            ->willReturn($records);
+
+        $commentRepository = $this->createMock(CommentRepository::class);
+        $commentRepository->expects(self::once())->method('countAllByRecords')->willReturn([]);
+        $commentRepository->expects(self::once())->method('countTodosByRecords')->willReturn([]);
+        $commentRepository->expects(self::never())->method('countAllByRecord');
+        $commentRepository->expects(self::never())->method('countTodosByRecord');
+
+        $backendUserRepository = $this->createMock(BackendUserRepository::class);
+        // No record carries an assignee, so the user lookup must be skipped entirely
+        // rather than issued once per record.
+        $backendUserRepository->expects(self::never())->method('getDisplayNamesByUids');
+        $backendUserRepository->expects(self::never())->method('getUsernameByUid');
+
+        $subject = new class($recordRepository, $commentRepository, $backendUserRepository) extends RecordSummaryService {
+            protected function areTodosEnabled(): bool
+            {
+                return true;
+            }
+
+            protected function isVisible(): bool
+            {
+                return true;
+            }
+
+            protected function isTableUsable(string $table): bool
+            {
+                return true;
+            }
+
+            /**
+             * @param array<string, mixed> $record
+             */
+            protected function isRecordAccessible(string $table, array $record): bool
+            {
+                return true;
+            }
+
+            /**
+             * @param array<string, mixed> $record
+             */
+            protected function capabilitiesFor(array $record): CapabilitySummary
+            {
+                return new CapabilitySummary(true, true, true, true);
+            }
+        };
+
+        self::assertCount(25, $subject->buildForItems($items));
+    }
+}


### PR DESCRIPTION
Implements #281 (CP-5).

> **Base branch is `feature/283-frontend-api-feature-flag`** (#290), not `main`, because this endpoint is gated by the flag introduced there. Review #290 first; this diff shows only the CP-5 changes. Retarget to `main` once #290 lands.

## Deviation from the issue — please confirm

The issue asks for *"`toArray()` with raw values only"*. **That would break the backend**, contradicting the issue's own criterion "Existing backend rendering unaffected by the DTO split". `StatusItem::toArray()` is an existing contract:

- `Resources/Public/JavaScript/filter-status.js:259-270` builds table rows from `item.statusIcon`, `item.recordIcon`, `item.assigneeAvatar`, `item.todo`, `item.todoShareUrl`, `item.updated`, `item.updatedRaw`
- `ConfigurableContentStatusList.html:47`, `ContentUpdateList.html:31`, `ContentCommentList.html:24` render the same keys through `f:format.raw`

So instead of reworking it, this adds a **dedicated `RecordSummary` DTO** in exactly the response shape the issue specifies. `StatusItem` and `CommentItem` are untouched. All three acceptance criteria are met, with zero backend regression risk. Confirmed with @k.michalik before implementing.

## Endpoint

```
POST /content-planner/api/summary
{"items": [{"table": "pages", "uid": 12}, {"table": "tt_content", "uid": 34}]}
```

Per item: `{table, uid, status|null, assignee|null, comments: {total, todoTotal, todoResolved}, capabilities: {…}}`.

- Icons are **identifiers**, colours **hex** — rendering and escaping stay with the consumer
- `comments.total` counts open comments including replies, matching the backend badge (`countAllByRecord()` defaults). To-do counters are zero while `commentTodos` is off, again matching the backend
- Forbidden / non-existent records are **omitted**, so one bad element cannot spoil a page's request. Documented that consumers must match on `table`+`uid` rather than assume order or length
- Batch capped at 500 items (400 beyond that)

## Batching

Four new batched repository methods replace what would otherwise be per-record lookups. `findByUid()` now delegates to `findAllByUids()`, so there is one query definition rather than two — this also brought `RecordRepository` back under the PHPStan cognitive-complexity limit that the new method had pushed it over (the project's baseline is empty, so ignoring the rule was not an option).

## Three things worth a reviewer's eye

**1. I wrote a fake test and removed it.** My first attempt at pinning the "O(1) queries" criterion used DBAL's `SQLLogger` — removed in current DBAL, and my counter was wired to nothing. It would have compared `0 == 0` and stayed green no matter how badly batching regressed. Replaced with `RecordSummaryServiceBatchingTest`, which mocks the repositories and asserts 25 records cause each batched method exactly `once()` and the per-record methods `never()`. That is the invariant that actually guards the criterion.

**2. `getUsernameByUid()` HTML-escapes; the batched variant deliberately does not.** Pre-escaping would put `&amp;` into a JSON payload — exactly the HTML leakage this issue is about. `getDisplayNamesByUids()` returns raw names; a test writes `Ann & Bob` into the DB and asserts both behaviours.

**3. `Colors::getHex()` throws on an unknown colour code.** A status row with an empty or hand-edited `color` would have turned a whole batch into a 500. `StatusSummary::fromStatus()` checks against `Colors::STATUS_COLORS` first and falls back to `colorHex: null`.

Also carried over from `findByUid()`: the **table whitelist**, since the table name reaches `getQueryBuilderForTable()` straight from request input. A test asserts an unregistered table yields nothing.

## Test plan

- [x] 45 new tests. Batched repository methods are each asserted **equal to their per-record counterpart** for every fixture uid, so the two cannot drift
- [x] `serializesWithoutAnyHtmlFragment` / `theResponseCarriesNoHtml` assert the payload contains no `<`, no `&amp;`, no `badge`
- [x] Both route-gating directions: absent while the flag is off, present as a POST route once on
- [x] Full suite: 138 unit + 383 functional, 0 failures (3 pre-existing v14-only skips). This exercises the `findByUid` delegation across every existing caller
- [x] PHPStan level 6: no errors. `php-cs-fixer` clean on all changed files
- [x] Doc cross-references verified
- [ ] Manual check against a real page: enable the flag, POST a page uid plus its `tt_content` uids, compare the counters against the backend badges
- [ ] Manual check that the record filter and the dashboard widgets still render (they use the untouched `StatusItem::toArray()`)

## Note

`capabilities.canViewComments` is always `true`: `PermissionUtility` has no dedicated view permission, so seeing comments follows from the visibility check already applied to the whole request. Flagging in case a distinct permission is wanted later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional frontend API endpoint for retrieving structured record summaries.
  * Summaries include status, assignee, comment and to-do counts, and available capabilities.
  * Supports batched requests of up to 500 records while omitting inaccessible or invalid records.
  * Added consistent serialized output without HTML fragments.

* **Bug Fixes**
  * Improved handling of malformed requests, unauthorized access, missing records, and invalid items.

* **Documentation**
  * Documented endpoint usage, response fields, limits, and authentication behavior.

* **Tests**
  * Added comprehensive coverage for API, summaries, batching, repositories, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->