### PR TITLE
feat: add a JSON endpoint for the status selection (#280)

### DIFF
--- a/Classes/Controller/ApiController.php
+++ b/Classes/Controller/ApiController.php
@@ -16,7 +16,7 @@ namespace Xima\XimaTypo3ContentPlanner\Controller;
 use Psr\Http\Message\{ResponseInterface, ServerRequestInterface};
 use TYPO3\CMS\Core\Http\JsonResponse;
 use Xima\XimaTypo3ContentPlanner\Domain\Model\Dto\Summary\RecordSummary;
-use Xima\XimaTypo3ContentPlanner\Service\RecordSummaryService;
+use Xima\XimaTypo3ContentPlanner\Service\{RecordSummaryService, StatusSelectionApiService};
 use Xima\XimaTypo3ContentPlanner\Utility\Security\PermissionUtility;
 
 use function array_map;
@@ -38,7 +38,35 @@ class ApiController
      */
     private const MAX_ITEMS = 500;
 
-    public function __construct(private readonly RecordSummaryService $recordSummaryService) {}
+    public function __construct(
+        private readonly RecordSummaryService $recordSummaryService,
+        private readonly StatusSelectionApiService $statusSelectionApiService,
+    ) {}
+
+    /**
+     * Returns the statuses selectable for one record, filtered exactly as the backend
+     * menus are, because the same PrepareStatusSelectionEvent runs.
+     */
+    public function statusSelectionAction(ServerRequestInterface $request): ResponseInterface
+    {
+        $table = (string) ($request->getQueryParams()['table'] ?? '');
+        $uid = (int) ($request->getQueryParams()['uid'] ?? 0);
+
+        if ('' === $table || $uid <= 0) {
+            return new JsonResponse(['error' => 'Both a table and a uid are required'], 400);
+        }
+
+        if (!PermissionUtility::checkContentStatusVisibility()) {
+            return new JsonResponse(['error' => 'Content planner is not visible for this user'], 403);
+        }
+
+        $selection = $this->statusSelectionApiService->buildForRecord($table, $uid);
+        if (null === $selection) {
+            return new JsonResponse(['error' => 'Record not found or not accessible'], 404);
+        }
+
+        return new JsonResponse($selection->toArray());
+    }
 
     /**
      * Returns status, assignee and comment counters for many records in one request.

--- a/Classes/Domain/Model/Dto/Summary/StatusSelection.php
+++ b/Classes/Domain/Model/Dto/Summary/StatusSelection.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Domain\Model\Dto\Summary;
+
+use function array_map;
+use function array_values;
+
+/**
+ * StatusSelection.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final readonly class StatusSelection
+{
+    /**
+     * @param StatusSelectionItem[] $items
+     */
+    public function __construct(
+        public string $table,
+        public int $uid,
+        public array $items,
+        public bool $canUnset,
+    ) {}
+
+    /**
+     * @return array{table: string, uid: int, items: list<array<string, mixed>>, canUnset: bool}
+     */
+    public function toArray(): array
+    {
+        return [
+            'table' => $this->table,
+            'uid' => $this->uid,
+            'items' => array_map(
+                static fn (StatusSelectionItem $item): array => $item->toArray(),
+                array_values($this->items),
+            ),
+            'canUnset' => $this->canUnset,
+        ];
+    }
+}

--- a/Classes/Domain/Model/Dto/Summary/StatusSelectionItem.php
+++ b/Classes/Domain/Model/Dto/Summary/StatusSelectionItem.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Domain\Model\Dto\Summary;
+
+/**
+ * StatusSelectionItem.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final readonly class StatusSelectionItem
+{
+    public function __construct(
+        public StatusSummary $status,
+        public bool $current,
+    ) {}
+
+    /**
+     * Unlike the backend menus, which drop the active status because picking it again is
+     * a no-op, the API reports it and flags it — a consumer needs it to render the
+     * selected entry.
+     *
+     * @return array{uid: int, title: string, colorName: string, colorHex: string|null, iconIdentifier: string, current: bool}
+     */
+    public function toArray(): array
+    {
+        return $this->status->toArray() + ['current' => $this->current];
+    }
+}

--- a/Classes/Service/StatusSelectionApiService.php
+++ b/Classes/Service/StatusSelectionApiService.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Service;
+
+use Doctrine\DBAL\Exception;
+use Xima\XimaTypo3ContentPlanner\Configuration;
+use Xima\XimaTypo3ContentPlanner\Domain\Model\Dto\Summary\{StatusSelection, StatusSelectionItem, StatusSummary};
+use Xima\XimaTypo3ContentPlanner\Domain\Repository\{RecordRepository, StatusRepository};
+use Xima\XimaTypo3ContentPlanner\Manager\StatusSelectionManager;
+use Xima\XimaTypo3ContentPlanner\Utility\ExtensionUtility;
+use Xima\XimaTypo3ContentPlanner\Utility\Security\PermissionUtility;
+
+use function is_array;
+
+/**
+ * StatusSelectionApiService.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+class StatusSelectionApiService
+{
+    public function __construct(
+        private readonly StatusRepository $statusRepository,
+        private readonly RecordRepository $recordRepository,
+        private readonly StatusSelectionManager $statusSelectionManager,
+    ) {}
+
+    /**
+     * Builds the selectable statuses for a record, running PrepareStatusSelectionEvent so
+     * a project listener restricts the API exactly as it restricts the backend menus.
+     *
+     * The selection handed to the event is keyed by status uid, the convention every
+     * backend selection builder already follows, so a listener unsetting a status by key
+     * takes effect here unchanged. A listener that instead rewrites entry *values* has to
+     * branch on the event's context, which it must do anyway — the value shape already
+     * differs between the list, dropdown and context-menu builders.
+     *
+     * @return StatusSelection|null null when the record is not readable for this user
+     *
+     * @throws Exception
+     */
+    public function buildForRecord(string $table, int $uid): ?StatusSelection
+    {
+        if (!$this->isVisible() || !$this->isTableUsable($table)) {
+            return null;
+        }
+
+        $record = $this->recordRepository->findByUid($table, $uid, ignoreVisibilityRestriction: true);
+        if (!is_array($record) || !$this->isRecordAccessible($table, $record)) {
+            return null;
+        }
+
+        $currentStatusUid = (int) ($record[Configuration::FIELD_STATUS] ?? 0);
+        $candidates = $this->collectCandidates($currentStatusUid);
+
+        $selection = $candidates;
+        $this->statusSelectionManager->prepareStatusSelection(
+            $this,
+            $table,
+            $uid,
+            $selection,
+            0 !== $currentStatusUid ? $currentStatusUid : null,
+        );
+
+        $items = [];
+        foreach ($selection as $key => $entry) {
+            // Only keys that were offered as statuses are reported; a listener adding its
+            // own unrelated entries cannot inject them into the status list.
+            if ($entry instanceof StatusSelectionItem && isset($candidates[$key])) {
+                $items[] = $entry;
+            }
+        }
+
+        return new StatusSelection(
+            table: $table,
+            uid: $uid,
+            items: $items,
+            canUnset: 0 !== $currentStatusUid && $this->canUnsetStatus(),
+        );
+    }
+
+    /*
+     * Global TYPO3 state sits behind these seams, mirroring RecordSummaryService.
+     */
+
+    protected function isVisible(): bool
+    {
+        return PermissionUtility::checkContentStatusVisibility();
+    }
+
+    protected function isTableUsable(string $table): bool
+    {
+        return ExtensionUtility::isRegisteredRecordTable($table) && PermissionUtility::isTableAllowedForUser($table);
+    }
+
+    /**
+     * @param array<string, mixed> $record
+     */
+    protected function isRecordAccessible(string $table, array $record): bool
+    {
+        return PermissionUtility::checkAccessForRecord($table, $record);
+    }
+
+    protected function canChangeStatus(): bool
+    {
+        return PermissionUtility::canChangeStatus();
+    }
+
+    protected function canUnsetStatus(): bool
+    {
+        return PermissionUtility::canUnsetStatus();
+    }
+
+    protected function isStatusAllowed(int $statusUid): bool
+    {
+        return PermissionUtility::isStatusAllowedForUser($statusUid);
+    }
+
+    /**
+     * Mirrors AbstractSelectionService::addAllStatusItems(), which is what makes the
+     * response honour `allowed_statuses` from be_groups.
+     *
+     * Keys are written as strings to match the backend selection builders, but PHP
+     * normalises numeric keys to integers — which is why a listener may unset either
+     * form.
+     *
+     * @return array<array-key, StatusSelectionItem>
+     */
+    private function collectCandidates(int $currentStatusUid): array
+    {
+        if (!$this->canChangeStatus()) {
+            return [];
+        }
+
+        $candidates = [];
+        foreach ($this->statusRepository->findAll() as $status) {
+            $statusUid = (int) $status->getUid();
+            if (!$this->isStatusAllowed($statusUid)) {
+                continue;
+            }
+
+            $candidates[(string) $statusUid] = new StatusSelectionItem(
+                status: StatusSummary::fromStatus($status),
+                current: $statusUid === $currentStatusUid,
+            );
+        }
+
+        return $candidates;
+    }
+}

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -51,6 +51,11 @@ if (Xima\XimaTypo3ContentPlanner\Utility\ExtensionUtility::isFrontendApiEnabled(
         'methods' => ['POST'],
         'target' => Xima\XimaTypo3ContentPlanner\Controller\ApiController::class.'::summaryAction',
     ];
+    $routes['ximatypo3contentplanner_api_statusselection'] = [
+        'path' => '/content-planner/api/status-selection',
+        'methods' => ['GET'],
+        'target' => Xima\XimaTypo3ContentPlanner\Controller\ApiController::class.'::statusSelectionAction',
+    ];
 }
 
 return $routes;

--- a/Documentation/DeveloperCorner/FrontendApi.rst
+++ b/Documentation/DeveloperCorner/FrontendApi.rst
@@ -186,6 +186,69 @@ Capabilities
     follows from the visibility check applied to the whole request — if a record
     appears in ``items`` at all, its comments are readable.
 
+..  _frontend-api-status-selection:
+
+Status selection
+----------------
+
+..  code-block:: none
+
+    GET /content-planner/api/status-selection?table=pages&uid=12
+
+Returns the statuses selectable for one record, so a frontend dropdown offers
+exactly what the backend offers.
+
+..  code-block:: json
+
+    {
+      "table": "pages",
+      "uid": 12,
+      "items": [
+        {
+          "uid": 1,
+          "title": "Draft",
+          "colorName": "blue",
+          "colorHex": "#64bbc8",
+          "iconIdentifier": "flag-blue",
+          "current": false
+        }
+      ],
+      "canUnset": true
+    }
+
+Responds 400 without both parameters, 403 when the content planner is not
+visible for the user, and 404 for a record that does not exist or that the user
+may not read.
+
+Contract notes:
+
+The selection event runs
+    The list is passed through
+    :ref:`PrepareStatusSelectionEvent <events>` just like every backend menu, so a
+    project listener that restricts statuses restricts this response identically.
+
+    The selection handed to the event is **keyed by status uid** — the convention
+    all backend selection builders already follow. A listener unsetting a status
+    by key therefore works unchanged. A listener that rewrites entry *values* has
+    to branch on ``$event->getContext()``, which it must do anyway, since the
+    value shape already differs between the list, dropdown and context-menu
+    builders. Entries a listener *adds* under keys that were not offered as
+    statuses are ignored.
+
+Group restrictions apply
+    Candidates are collected the same way as
+    ``AbstractSelectionService::addAllStatusItems()``, so ``allowed_statuses``
+    from :ref:`be_groups <permissions>` is honoured.
+
+The current status is included
+    Unlike the backend menus, which omit the active status because picking it
+    again is a no-op, the response reports it with ``current: true`` — a consumer
+    needs it to render the selected entry.
+
+``canUnset``
+    True only when the record actually has a status *and* the user holds the
+    unset permission. It is independent of the selection listener.
+
 Checking a flag
 ===============
 

--- a/Tests/Functional/Controller/ApiControllerTest.php
+++ b/Tests/Functional/Controller/ApiControllerTest.php
@@ -164,6 +164,48 @@ final class ApiControllerTest extends AbstractFunctionalTestCase
         self::assertCount(1, $payload['items']);
     }
 
+    #[Test]
+    public function theStatusSelectionRouteIsAlsoGatedByTheFlag(): void
+    {
+        self::assertArrayNotHasKey('ximatypo3contentplanner_api_statusselection', $this->loadAjaxRoutes());
+
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY][Configuration::FEATURE_FRONTEND_API] = 1;
+        $routes = $this->loadAjaxRoutes();
+
+        self::assertSame('/content-planner/api/status-selection', $routes['ximatypo3contentplanner_api_statusselection']['path']);
+        self::assertSame(['GET'], $routes['ximatypo3contentplanner_api_statusselection']['methods']);
+    }
+
+    #[Test]
+    public function statusSelectionReturnsDataOnlyItems(): void
+    {
+        $response = $this->subject->statusSelectionAction($this->getRequestWith(['table' => 'pages', 'uid' => '1']));
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = json_decode((string) $response->getBody(), true);
+        self::assertSame(['table', 'uid', 'items', 'canUnset'], array_keys($payload));
+        self::assertSame(
+            ['uid', 'title', 'colorName', 'colorHex', 'iconIdentifier', 'current'],
+            array_keys($payload['items'][0]),
+        );
+        self::assertStringNotContainsString('<', (string) $response->getBody());
+    }
+
+    #[Test]
+    public function statusSelectionRequiresBothTableAndUid(): void
+    {
+        self::assertSame(400, $this->subject->statusSelectionAction($this->getRequestWith(['uid' => '1']))->getStatusCode());
+        self::assertSame(400, $this->subject->statusSelectionAction($this->getRequestWith(['table' => 'pages']))->getStatusCode());
+        self::assertSame(400, $this->subject->statusSelectionAction($this->getRequestWith(['table' => 'pages', 'uid' => '0']))->getStatusCode());
+    }
+
+    #[Test]
+    public function statusSelectionReturnsNotFoundForAnInaccessibleRecord(): void
+    {
+        self::assertSame(404, $this->subject->statusSelectionAction($this->getRequestWith(['table' => 'pages', 'uid' => '9999']))->getStatusCode());
+        self::assertSame(404, $this->subject->statusSelectionAction($this->getRequestWith(['table' => 'be_users', 'uid' => '1']))->getStatusCode());
+    }
+
     /**
      * @param array<string, mixed> $body
      */
@@ -180,5 +222,14 @@ final class ApiControllerTest extends AbstractFunctionalTestCase
     private function loadAjaxRoutes(): array
     {
         return require dirname(__DIR__, 3).'/Configuration/Backend/AjaxRoutes.php';
+    }
+
+    /**
+     * @param array<string, string> $queryParams
+     */
+    private function getRequestWith(array $queryParams): ServerRequest
+    {
+        return (new ServerRequest('https://example.com/typo3/ajax/content-planner/api/status-selection', 'GET'))
+            ->withQueryParams($queryParams);
     }
 }

--- a/Tests/Functional/Service/StatusSelectionApiServiceTest.php
+++ b/Tests/Functional/Service/StatusSelectionApiServiceTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Tests\Functional\Service;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\EventDispatcher\EventDispatcher;
+use Xima\XimaTypo3ContentPlanner\Domain\Model\Dto\Summary\StatusSelection;
+use Xima\XimaTypo3ContentPlanner\Domain\Repository\{RecordRepository, StatusRepository};
+use Xima\XimaTypo3ContentPlanner\Event\PrepareStatusSelectionEvent;
+use Xima\XimaTypo3ContentPlanner\Manager\StatusSelectionManager;
+use Xima\XimaTypo3ContentPlanner\Service\StatusSelectionApiService;
+use Xima\XimaTypo3ContentPlanner\Tests\Functional\AbstractFunctionalTestCase;
+
+/**
+ * StatusSelectionApiServiceTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class StatusSelectionApiServiceTest extends AbstractFunctionalTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importSharedDataSet('status.csv');
+        $this->importCSVDataSet(__DIR__.'/Fixtures/summary_pages.csv');
+        $this->loginBackendUser();
+        $this->setUpBackendRequest();
+    }
+
+    #[Test]
+    public function offersEveryAllowedStatus(): void
+    {
+        $selection = $this->buildFor('pages', 1);
+
+        self::assertNotNull($selection);
+        self::assertCount(3, $selection->items);
+        self::assertSame([1, 2, 3], array_map(static fn ($item): int => $item->status->uid, $selection->items));
+    }
+
+    #[Test]
+    public function flagsTheCurrentStatusAndOffersUnsetting(): void
+    {
+        // Fixture page 1 carries status 1
+        $selection = $this->buildFor('pages', 1);
+
+        self::assertNotNull($selection);
+        $current = array_values(array_filter($selection->items, static fn ($item): bool => $item->current));
+        self::assertCount(1, $current);
+        self::assertSame(1, $current[0]->status->uid);
+        self::assertTrue($selection->canUnset);
+    }
+
+    #[Test]
+    public function doesNotOfferUnsettingForARecordWithoutStatus(): void
+    {
+        // Fixture page 3 has no status
+        $selection = $this->buildFor('pages', 3);
+
+        self::assertNotNull($selection);
+        self::assertFalse($selection->canUnset);
+        self::assertSame([], array_filter($selection->items, static fn ($item): bool => $item->current));
+    }
+
+    #[Test]
+    public function aListenerRestrictingTheSelectionRestrictsTheResponseIdentically(): void
+    {
+        // The acceptance criterion. Backend selection builders key status entries by uid,
+        // so a listener unsetting that key must take effect here too.
+        $selection = $this->buildFor('pages', 1, static function (array $entries): array {
+            unset($entries['2']);
+
+            return $entries;
+        });
+
+        self::assertNotNull($selection);
+        self::assertSame([1, 3], array_map(static fn ($item): int => $item->status->uid, $selection->items));
+    }
+
+    #[Test]
+    public function aListenerEmptyingTheSelectionYieldsNoItems(): void
+    {
+        $selection = $this->buildFor('pages', 1, static fn (array $entries): array => []);
+
+        self::assertNotNull($selection);
+        self::assertSame([], $selection->items);
+        // Unsetting is governed by permissions, not by the selection listener.
+        self::assertTrue($selection->canUnset);
+    }
+
+    #[Test]
+    public function ignoresEntriesAListenerInvents(): void
+    {
+        $selection = $this->buildFor('pages', 1, static function (array $entries): array {
+            $entries['999'] = 'something the listener added';
+            $entries['divider'] = '<hr>';
+
+            return $entries;
+        });
+
+        self::assertNotNull($selection);
+        self::assertSame([1, 2, 3], array_map(static fn ($item): int => $item->status->uid, $selection->items));
+    }
+
+    #[Test]
+    public function returnsNullForAnUnregisteredTable(): void
+    {
+        self::assertNull($this->buildFor('be_users', 1));
+    }
+
+    #[Test]
+    public function returnsNullForAMissingRecord(): void
+    {
+        self::assertNull($this->buildFor('pages', 9999));
+    }
+
+    #[Test]
+    public function serializesWithoutAnyHtmlFragment(): void
+    {
+        $selection = $this->buildFor('pages', 1);
+
+        self::assertNotNull($selection);
+        $payload = (string) json_encode($selection->toArray());
+        self::assertStringNotContainsString('<', $payload);
+        self::assertStringNotContainsString('&amp;', $payload);
+    }
+
+    /**
+     * @param (callable(array<string, mixed>): array<string, mixed>)|null $listener
+     */
+    private function buildFor(string $table, int $uid, ?callable $listener = null): ?StatusSelection
+    {
+        $dispatcher = $this->createMock(EventDispatcher::class);
+        $dispatcher->method('dispatch')->willReturnCallback(
+            static function (PrepareStatusSelectionEvent $event) use ($listener): PrepareStatusSelectionEvent {
+                if (null !== $listener) {
+                    $event->setSelection($listener($event->getSelection()));
+                }
+
+                return $event;
+            },
+        );
+
+        $subject = new StatusSelectionApiService(
+            $this->get(StatusRepository::class),
+            $this->get(RecordRepository::class),
+            new StatusSelectionManager($dispatcher),
+        );
+
+        return $subject->buildForRecord($table, $uid);
+    }
+}


### PR DESCRIPTION
Implements #280 (CP-4).

> **Base branch is `feature/281-batch-summary-endpoint`** (#292), which itself targets #290. Review order: #290 → #292 → this. The diff shown here is CP-4 only; retarget as the stack lands.

## Endpoint

```
GET /content-planner/api/status-selection?table=pages&uid=12
```

```json
{
  "table": "pages", "uid": 12,
  "items": [{"uid": 1, "title": "Draft", "colorName": "blue",
             "colorHex": "#64bbc8", "iconIdentifier": "flag-blue", "current": false}],
  "canUnset": true
}
```

400 without both parameters, 403 when the content planner is not visible, 404 for a record that does not exist or is not readable.

## How the "identical restriction" criterion is actually met

This was the substantive part, and it is not automatic. `PrepareStatusSelectionEvent` receives a selection whose **values differ per context**: `ListSelectionService` and `DropDownSelectionService` insert raw HTML strings, `ContextMenuSelectionService` inserts nested arrays. A listener therefore *cannot* portably filter on values.

What all three builders share is the **key**: `(string) $status->getUid()`.

So this endpoint builds its selection with the same uid keying and dispatches the same event through the same manager. A listener doing `unset($selection['2'])` restricts backend menus and this response identically — asserted by `aListenerRestrictingTheSelectionRestrictsTheResponseIdentically`.

Two related behaviours, both tested:
- A listener that **empties** the selection yields no items (but `canUnset` is unaffected — that is a permission, not a selection concern)
- Entries a listener **adds** under keys that were never offered as statuses are ignored, so it cannot inject arbitrary things into the status list

Documented in the new chapter, including that a value-rewriting listener must branch on `$event->getContext()` — which it already has to, given the pre-existing shape differences.

## A detail PHPStan surfaced

PHP normalises numeric string keys to **integers**, so my `array<string, StatusSelectionItem>` annotation was wrong (now `array<array-key, …>`). Functionally harmless — `isset($a['1'])` and `isset($a[1])` are equivalent — but it means a listener may use either form, which is worth knowing and is now documented. Note the event's own `array<string, mixed>` PHPDoc has the same inaccuracy for status entries; left alone here as it is pre-existing and out of scope.

## Deliberate difference from the backend

Backend menus **omit** the currently active status (`compareStatus()` early-returns) because clicking it is a no-op. The API instead reports it with `current: true`, since a frontend dropdown needs it to render the selected entry. This is what the issue asks for; called out in the docs so the difference is not mistaken for a bug.

## Group restrictions

Candidates come from the same path as `AbstractSelectionService::addAllStatusItems()` — `canChangeStatus()` then `isStatusAllowedForUser()` per status — which is what makes `allowed_statuses` from `be_groups` apply.

## Test plan

- [x] 9 service tests including the listener-restriction criterion, the empty-selection case, invented-key rejection, current-status flagging, and `canUnset` for a record with and without a status
- [x] 4 controller tests: flag gating for the new route (both directions), the data-only response shape, parameter validation, 404 for inaccessible records
- [x] `serializesWithoutAnyHtmlFragment` asserts no `<` and no `&amp;` in the payload
- [x] Full suite: 138 unit + 396 functional, 0 failures (3 pre-existing v14-only skips)
- [x] PHPStan level 6 clean; `php-cs-fixer` clean on all changed files; doc references verified
- [ ] Manual check with a project listener that restricts statuses per table, comparing a backend dropdown against the endpoint
- [ ] Manual check that a `be_groups` `allowed_statuses` restriction shows up in the response