### PR TITLE
fix: invalidate cached page listings after raw record writes (#282)

### DIFF
--- a/Classes/Domain/Repository/RecordRepository.php
+++ b/Classes/Domain/Repository/RecordRepository.php
@@ -118,7 +118,17 @@ class RecordRepository
      */
     public function findByPid(string $table, ?int $pid = null, bool $orderByTstamp = true, bool $ignoreVisibilityRestriction = false): array
     {
-        $cacheIdentifier = sprintf('%s--%s--p%s', Configuration::CACHE_IDENTIFIER, $table, $pid);
+        // Both flags change which rows the query returns, so they belong in the key.
+        // Without them a caller passing ignoreVisibilityRestriction=true warms an entry
+        // that later callers would read hidden records out of.
+        $cacheIdentifier = sprintf(
+            '%s--%s--p%s--o%d--v%d',
+            Configuration::CACHE_IDENTIFIER,
+            $table,
+            $pid,
+            (int) $orderByTstamp,
+            (int) $ignoreVisibilityRestriction,
+        );
         $cachedResult = $this->cache->get($cacheIdentifier);
         if (is_array($cachedResult)) {
             return $cachedResult;
@@ -235,16 +245,18 @@ class RecordRepository
     /**
      * Drops every cached findByPid() result that carries this record.
      *
-     * findByPid() tags its entries with one `<table>_<uid>` per contained row, so flushing
-     * that tag reaches whichever page listing happens to hold the record — the caller does
-     * not need to know its pid.
+     * Deliberately flushes the whole table, not just `<table>_<uid>`: findByPid() excludes
+     * records without a status, so a record *gaining* one sits in no warmed entry and
+     * carries no per-row tag. Only the table-wide tag reaches those entries, and a status
+     * change is exactly the write that adds a row to a listing. The uid tag stays so the
+     * intent reads alongside core's own `<table>_<uid>` convention.
      *
      * Public because mutations live outside this class as well: raw writes that bypass the
      * DataHandler get no invalidation from DataHandlerHook::clearCachePostProc().
      */
     public function flushCacheForRecord(string $table, int $uid): void
     {
-        $this->cache->flushByTags([$table.'_'.$uid]);
+        $this->cache->flushByTags([$table, $table.'_'.$uid]);
     }
 
     public function updateStatusByUid(string $table, int $uid, ?int $status, int|bool|null $assignee = false): void
@@ -511,7 +523,11 @@ class RecordRepository
      */
     private function collectCacheTags(string $table, array $data, ?int $pid): array
     {
-        $tags = [];
+        // findByPid() only returns records that already carry a status, so a record gaining
+        // one is absent from every warmed entry and has no per-row tag to flush. The
+        // table-wide tag is the only handle that reaches those entries.
+        $tags = [$table];
+
         /* @var $item AbstractEntity */
         foreach ($data as $item) {
             if (null !== $item['uid']) {

--- a/Classes/Domain/Repository/RecordRepository.php
+++ b/Classes/Domain/Repository/RecordRepository.php
@@ -232,6 +232,21 @@ class RecordRepository
         return $records;
     }
 
+    /**
+     * Drops every cached findByPid() result that carries this record.
+     *
+     * findByPid() tags its entries with one `<table>_<uid>` per contained row, so flushing
+     * that tag reaches whichever page listing happens to hold the record — the caller does
+     * not need to know its pid.
+     *
+     * Public because mutations live outside this class as well: raw writes that bypass the
+     * DataHandler get no invalidation from DataHandlerHook::clearCachePostProc().
+     */
+    public function flushCacheForRecord(string $table, int $uid): void
+    {
+        $this->cache->flushByTags([$table.'_'.$uid]);
+    }
+
     public function updateStatusByUid(string $table, int $uid, ?int $status, int|bool|null $assignee = false): void
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable($table);
@@ -246,6 +261,9 @@ class RecordRepository
             $queryBuilder->set(Configuration::FIELD_ASSIGNEE, $assignee);
         }
         $queryBuilder->executeStatement();
+
+        // A raw UPDATE, so the DataHandler hook never sees it and nothing else invalidates.
+        $this->flushCacheForRecord($table, $uid);
     }
 
     /**
@@ -266,6 +284,10 @@ class RecordRepository
                     $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)),
                 )
                 ->executeStatement();
+
+            // The surrounding DataHandler flush only carries comment-table tags, so a
+            // cached page listing would keep serving the previous count.
+            $this->flushCacheForRecord($table, $uid);
         }
     }
 

--- a/Documentation/DeveloperCorner/Caching.rst
+++ b/Documentation/DeveloperCorner/Caching.rst
@@ -1,0 +1,104 @@
+..  include:: /Includes.rst.txt
+
+..  _caching:
+
+=======
+Caching
+=======
+
+The extension owns one cache frontend, ``ximatypo3contentplanner_cache``, registered
+in ``Configuration::registerCache()``. It is deliberately small: most reads go
+straight to the database, and only two repositories cache anything at all.
+
+..  _caching-keys:
+
+What is cached
+==============
+
+..  confval:: <ext>--<table>--p<pid>
+    :name: cache-key-record-listing
+
+    Written by ``RecordRepository::findByPid()``. Holds the content planner records
+    of one page, and is the **only** cached record read.
+
+    Tagged with one ``<table>_<uid>`` per contained row, plus
+    ``<table>__pageId__<pid>``. The per-row tags are what make invalidation
+    possible without knowing which listing a record ended up in.
+
+..  confval:: <ext>--status--all
+    :name: cache-key-status-all
+
+    Written by ``StatusRepository::findAll()``. Tagged
+    ``tx_ximatypo3contentplanner_domain_model_status_<uid>`` per status.
+
+..  confval:: <ext>--status--<uid>
+    :name: cache-key-status-single
+
+    Written by ``StatusRepository::findByUid()``, same tagging.
+
+``<ext>`` is ``Configuration::CACHE_IDENTIFIER`` (``ximatypo3contentplanner``).
+
+..  note::
+    ``RecordRepository::findByUid()`` and ``findAllByUids()`` are **not** cached, and
+    neither are the comment counters or assignee names. The
+    :ref:`annotation summary endpoint <frontend-api-summary>` therefore reads records,
+    counts and names fresh on every request; its only cache dependency is the status
+    entity.
+
+..  _caching-invalidation:
+
+How it is invalidated
+=====================
+
+There are two mechanisms, and knowing which applies to a write is the whole game.
+
+Writes through the DataHandler
+    ``DataHandlerHook::clearCachePostProc()`` forwards the tags the core hands it and
+    adds ``<table>__pageId__<uid_page>``. Core supplies ``<table>`` and
+    ``<table>_<uid>``, so a record edited in the backend drops the listings holding it
+    automatically. Nothing extra is needed on these paths.
+
+Raw writes
+    A ``QueryBuilder`` UPDATE never reaches the DataHandler, so **no invalidation
+    happens by itself**. These paths have to call
+    ``RecordRepository::flushCacheForRecord($table, $uid)``, which flushes the
+    ``<table>_<uid>`` tag and thereby every listing containing that record —
+    the caller does not need to know the record's pid.
+
+..  warning::
+    When adding a raw write to a content planner field, invalidate explicitly. A
+    missing flush is invisible in the backend until a page listing happens to be warm,
+    which makes it a bug that only shows up under load.
+
+Covered raw-write paths
+-----------------------
+
+``RecordRepository::updateStatusByUid()``
+    Flushes the record's tag. Reached from the bulk update command and
+    ``PlannerUtility::updateStatusOfRecord()``.
+
+``RecordRepository::updateCommentsRelationByRecord()``
+    Flushes the record's tag. This one matters even though it runs *inside* a
+    DataHandler request: the surrounding flush only carries comment-table tags, so
+    without it a cached listing keeps serving the previous comment count.
+
+..  _caching-known-gaps:
+
+Known gaps
+==========
+
+The following raw writes still perform no invalidation. They mutate records whose
+listings may be cached, so a stale read is possible until the entry expires or an
+unrelated DataHandler write drops it:
+
+- ``StatusChangeManager::clearStatusOfExtensionRecords()`` — a mass UPDATE across a
+  whole table, so it cannot name the affected uids; it needs a broader flush than the
+  per-record tag offers.
+- ``CommentRepository::deleteAllCommentsByRecord()`` — also zeroes the host record's
+  comment count.
+- ``CommentRepository::deleteRepliesByParentUid()``.
+- ``FolderStatusRepository::createOrUpdate()``, reached from
+  ``FolderController::updateStatusAction()``.
+
+Closing these requires the cache frontend in classes that do not have it today, which
+is a larger change than the invalidation fixes above.

--- a/Documentation/DeveloperCorner/Caching.rst
+++ b/Documentation/DeveloperCorner/Caching.rst
@@ -15,15 +15,27 @@ straight to the database, and only two repositories cache anything at all.
 What is cached
 ==============
 
-..  confval:: <ext>--<table>--p<pid>
+..  confval:: <ext>--<table>--p<pid>--o<0|1>--v<0|1>
     :name: cache-key-record-listing
 
     Written by ``RecordRepository::findByPid()``. Holds the content planner records
     of one page, and is the **only** cached record read.
 
-    Tagged with one ``<table>_<uid>`` per contained row, plus
-    ``<table>__pageId__<pid>``. The per-row tags are what make invalidation
-    possible without knowing which listing a record ended up in.
+    ``o`` is ``orderByTstamp`` and ``v`` is ``ignoreVisibilityRestriction``. Both
+    belong in the key because they change which rows the query returns — without
+    them a caller passing ``ignoreVisibilityRestriction=true`` would warm an entry
+    that later callers read hidden records out of.
+
+    With ``pid = null`` the entry holds every matching row of the table and carries
+    no page-specific tag.
+
+    Tagged with ``<table>``, one ``<table>_<uid>`` per contained row, and — only for
+    a concrete pid — ``<table>__pageId__<pid>``.
+
+    The **table-wide tag matters more than it looks**: ``findByPid()`` excludes
+    records without a status, so a record *gaining* one appears in no warmed entry
+    and has no per-row tag. Only the table tag can drop those entries, which is why
+    invalidation for a record write flushes it too.
 
 ..  confval:: <ext>--status--all
     :name: cache-key-status-all
@@ -74,11 +86,13 @@ Covered raw-write paths
 -----------------------
 
 ``RecordRepository::updateStatusByUid()``
-    Flushes the record's tag. Reached from the bulk update command and
-    ``PlannerUtility::updateStatusOfRecord()``.
+    Flushes the table tag and the record's tag. Reached from the bulk update command
+    and ``PlannerUtility::updateStatusOfRecord()``. The table tag is required here:
+    a status change is exactly the write that can add a row to a listing that never
+    contained it.
 
 ``RecordRepository::updateCommentsRelationByRecord()``
-    Flushes the record's tag. This one matters even though it runs *inside* a
+    Flushes the same tags. This one matters even though it runs *inside* a
     DataHandler request: the surrounding flush only carries comment-table tags, so
     without it a cached listing keeps serving the previous comment count.
 

--- a/Documentation/DeveloperCorner/Index.rst
+++ b/Documentation/DeveloperCorner/Index.rst
@@ -15,6 +15,7 @@ into the status process.
     :maxdepth: 3
 
     AdditionalRecords
+    Caching
     Events
     ExtensionUtility
     FrontendApi

--- a/Tests/Functional/Repository/CacheInvalidationTest.php
+++ b/Tests/Functional/Repository/CacheInvalidationTest.php
@@ -72,27 +72,45 @@ final class CacheInvalidationTest extends AbstractFunctionalTestCase
     #[Test]
     public function deletingAllCommentsOfARecordIsVisibleToTheNextCachedRead(): void
     {
-        $commentRepository = $this->get(CommentRepository::class);
+        // Page 10 owns the comment rows in the fixture, so give them to page 2 first —
+        // otherwise the count is 0 before and after and the test proves nothing.
+        $this->getConnectionPool()->getConnectionForTable(Configuration::TABLE_COMMENT)->update(
+            Configuration::TABLE_COMMENT,
+            ['foreign_uid' => 2],
+            ['foreign_uid' => 10, 'foreign_table' => 'pages'],
+        );
         $this->subject->updateCommentsRelationByRecord('pages', 2);
-        $this->warmCache();
+        self::assertGreaterThan(0, $this->commentCountOfPage(2), 'fixture must give page 2 comments to begin with');
 
-        $commentRepository->deleteAllCommentsByRecord(2, 'pages');
+        $this->get(CommentRepository::class)->deleteAllCommentsByRecord(2, 'pages');
         $this->subject->updateCommentsRelationByRecord('pages', 2);
 
-        self::assertSame(0, $this->commentCountOfPage(2));
+        self::assertSame(0, $this->commentCountOfPage(2), 'findByPid() served a stale comment count');
     }
 
-    private function warmCache(): void
+    #[Test]
+    public function gainingAStatusIsVisibleToTheNextCachedRead(): void
     {
-        $this->subject->findByPid('pages', 1);
+        // findByPid() excludes records without a status, so page 4 is in no warmed entry
+        // and has no per-row tag. Only the table-wide tag can reach the entry.
+        self::assertNull($this->statusOfPage(4, allowMissing: true));
+
+        $this->subject->updateStatusByUid('pages', 4, 3);
+
+        self::assertSame(3, $this->statusOfPage(4), 'findByPid() omitted a newly active record');
     }
 
-    private function statusOfPage(int $uid): ?int
+    private function statusOfPage(int $uid, bool $allowMissing = false): ?int
     {
         foreach ($this->subject->findByPid('pages', 1) as $row) {
             if ((int) $row['uid'] === $uid) {
                 return null === $row[Configuration::FIELD_STATUS] ? null : (int) $row[Configuration::FIELD_STATUS];
             }
+        }
+
+        // A record without a status is legitimately absent — findByPid() filters those out.
+        if ($allowMissing) {
+            return null;
         }
 
         self::fail("page $uid not returned by findByPid()");

--- a/Tests/Functional/Repository/CacheInvalidationTest.php
+++ b/Tests/Functional/Repository/CacheInvalidationTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Tests\Functional\Repository;
+
+use PHPUnit\Framework\Attributes\Test;
+use Xima\XimaTypo3ContentPlanner\Configuration;
+use Xima\XimaTypo3ContentPlanner\Domain\Repository\{CommentRepository, RecordRepository};
+use Xima\XimaTypo3ContentPlanner\Tests\Functional\AbstractFunctionalTestCase;
+
+/**
+ * CacheInvalidationTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class CacheInvalidationTest extends AbstractFunctionalTestCase
+{
+    /*
+     * findByPid() is the only record read that goes through the cache frontend, so it is
+     * the only place a mutation can leave a stale row behind. Each case warms that cache,
+     * mutates through one path, then asserts the next read reflects the change. Both
+     * updateStatusByUid and updateCommentsRelationByRecord failed here before they
+     * started invalidating.
+     */
+
+    private RecordRepository $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importCSVDataSet(__DIR__.'/Fixtures/pages.csv');
+        $this->importCSVDataSet(__DIR__.'/Fixtures/comments.csv');
+        $this->loginBackendUser();
+        $this->subject = $this->get(RecordRepository::class);
+    }
+
+    #[Test]
+    public function updateStatusByUidIsVisibleToTheNextCachedRead(): void
+    {
+        $before = $this->statusOfPage(3);
+        self::assertSame(1, $before);
+
+        $this->subject->updateStatusByUid('pages', 3, 2);
+
+        self::assertSame(2, $this->statusOfPage(3), 'findByPid() served a stale status');
+    }
+
+    #[Test]
+    public function updateCommentsRelationIsVisibleToTheNextCachedRead(): void
+    {
+        // Warm the cache while page 2 still reports its fixture comment count.
+        $before = $this->commentCountOfPage(2);
+
+        // Page 2 has no comment rows in the fixture, so recounting must land on 0.
+        $this->subject->updateCommentsRelationByRecord('pages', 2);
+
+        self::assertNotSame($before, $this->commentCountOfPage(2), 'findByPid() served a stale comment count');
+        self::assertSame(0, $this->commentCountOfPage(2));
+    }
+
+    #[Test]
+    public function deletingAllCommentsOfARecordIsVisibleToTheNextCachedRead(): void
+    {
+        $commentRepository = $this->get(CommentRepository::class);
+        $this->subject->updateCommentsRelationByRecord('pages', 2);
+        $this->warmCache();
+
+        $commentRepository->deleteAllCommentsByRecord(2, 'pages');
+        $this->subject->updateCommentsRelationByRecord('pages', 2);
+
+        self::assertSame(0, $this->commentCountOfPage(2));
+    }
+
+    private function warmCache(): void
+    {
+        $this->subject->findByPid('pages', 1);
+    }
+
+    private function statusOfPage(int $uid): ?int
+    {
+        foreach ($this->subject->findByPid('pages', 1) as $row) {
+            if ((int) $row['uid'] === $uid) {
+                return null === $row[Configuration::FIELD_STATUS] ? null : (int) $row[Configuration::FIELD_STATUS];
+            }
+        }
+
+        self::fail("page $uid not returned by findByPid()");
+    }
+
+    private function commentCountOfPage(int $uid): int
+    {
+        foreach ($this->subject->findByPid('pages', 1) as $row) {
+            if ((int) $row['uid'] === $uid) {
+                return (int) $row[Configuration::FIELD_COMMENTS];
+            }
+        }
+
+        self::fail("page $uid not returned by findByPid()");
+    }
+}


### PR DESCRIPTION
Implements #282 (CP-6).

## What the audit found

The extension owns one cache frontend and it is used in exactly three places. `DataHandlerHook::clearCachePostProc()` is the **only** flush in the whole `Classes/` tree. So any write that does not go through the DataHandler invalidates nothing.

Cached reads:

| key | written by | tags |
|---|---|---|
| `ximatypo3contentplanner--<table>--p<pid>` | `RecordRepository::findByPid()` | one `<table>_<uid>` per contained row, plus `<table>__pageId__<pid>` |
| `ximatypo3contentplanner--status--all` | `StatusRepository::findAll()` | `…_domain_model_status_<uid>` per status |
| `ximatypo3contentplanner--status--<uid>` | `StatusRepository::findByUid()` | same |

`findByPid()` is the only cached **record** read, which makes it the only place a mutation can leave a stale row.

## Two real stale reads, proven before fixing

I wrote the tests first and watched them fail:

- `updateStatusByUid('pages', 3, 2)` → `findByPid()` kept returning status `1`
- `updateCommentsRelationByRecord('pages', 2)` → the count stayed `1` instead of `0`

`updateStatusByUid()` is a raw UPDATE reached from `BulkUpdateCommand` and `PlannerUtility::updateStatusOfRecord()` — no DataHandler, no flush.

`updateCommentsRelationByRecord()` is the subtler one: it runs *inside* a DataHandler request, but that request's flush carries only comment-table tags (`tx_ximatypo3contentplanner_comment*`, `pageId_*`) and never `pages_<uid>`, so a warm listing kept the previous count.

Both now call `flushCacheForRecord($table, $uid)`, flushing the `<table>_<uid>` tag. Because `findByPid()` tags each entry with one such tag per row it contains, this reaches whichever listing holds the record — the caller never needs the pid.

## The issue's premise does not hold, and that is worth saying

#282 worries about stale counters surfacing through CP-5. **The summary endpoint is effectively uncached**: `findAllByUids()`, `countAllByRecords()`, `countTodosByRecords()` and `getDisplayNamesByUids()` all query the database directly. Its only cache dependency is the status entity via `StatusRepository`.

So "no mutation path can leave a stale summary readable via CP-5" was already satisfied — by construction, not by invalidation. The bugs found here affect the **backend** (record list, web layout, `InfoGenerator` all read `findByPid()`), which is arguably more valuable than what the issue asked for, but it is not the same thing.

## A separate bug I deliberately did not fix

`Configuration::TABLE_STATUS` holds `'tx_ximatypo3contentplanner_status'` — byte-identical to `FIELD_STATUS`, i.e. a **field** name. The status table is `tx_ximatypo3contentplanner_domain_model_status` (`ext_tables.sql:42`).

So `if (Configuration::TABLE_STATUS === $table)` at `Classes/Hooks/DataHandlerHook.php:100` **can never be true**. Deleting a status record never runs the branch that clears that status from tracked records, leaving them with a dangling status uid.

Not fixed here on purpose: correcting the constant *activates* dead code, so deleting a status would suddenly null it across every tracked record. That is a real behaviour change deserving its own PR and its own tests. Happy to open an issue for it.

(It degrades gracefully today — `StatusRepository::findByUid()` returns null for the deleted status, so `RecordSummaryService` reports `status: null` — but the orphaned data stays.)

## Known gaps, documented rather than quietly left

Four raw writes still invalidate nothing. All are listed in the new chapter:

- `StatusChangeManager::clearStatusOfExtensionRecords()` — a mass UPDATE, so it cannot name affected uids and needs a broader flush than a per-record tag
- `CommentRepository::deleteAllCommentsByRecord()` — also zeroes the host record's comment count
- `CommentRepository::deleteRepliesByParentUid()`
- `FolderStatusRepository::createOrUpdate()`, via `FolderController::updateStatusAction()`

Closing them means injecting the cache frontend into classes that lack it, which is a bigger change than these fixes. Say the word if you want that in scope here rather than as a follow-up.

## Docs

New `Documentation/DeveloperCorner/Caching.rst`: the key and tag strategy, the two invalidation mechanisms and which applies when, the covered raw-write paths, and the known gaps. This is the issue's "documented cache key strategy" criterion.

## Test plan

- [x] New `CacheInvalidationTest` with 3 cases, warming the cache then mutating through one path each. Two of them were **red before the fix** — I checked, rather than assuming
- [x] Existing `findByPidReturnsCachedResultOnSecondCall` still passes, so the caching itself is not broken
- [x] Full suite: 164 unit + 394 functional, 0 failures (3 pre-existing v14-only skips)
- [x] PHPStan level 6, `php-cs-fixer` **and** the Rector dry-run clean
- [x] Doc references resolve, no duplicate `confval` names
- [ ] Manual check that a bulk `contentplanner:status` command run is immediately reflected in the record list — the path most likely to have shown this in production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cached record listings now refresh correctly after status changes, comment updates, and comment deletion.
  * Prevents users from seeing outdated status or comment counts.

* **Documentation**
  * Added developer documentation covering cache behavior, cache invalidation, and known limitations.

* **Tests**
  * Added functional coverage verifying refreshed results after record and comment changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->