### PR TITLE
feat: add a JSON endpoint for status changes via the DataHandler (#279)

### DIFF
--- a/Classes/Controller/ApiController.php
+++ b/Classes/Controller/ApiController.php
@@ -22,7 +22,9 @@ use Xima\XimaTypo3ContentPlanner\Utility\Security\PermissionUtility;
 use function array_key_exists;
 use function array_map;
 use function count;
+use function ctype_digit;
 use function is_array;
+use function is_int;
 use function is_string;
 
 /**
@@ -64,12 +66,18 @@ class ApiController
         }
 
         $table = $body['table'];
-        $uid = (int) ($body['uid'] ?? 0);
-        if ('' === $table || $uid <= 0) {
+        $uid = $this->readPositiveInt($body['uid'] ?? null);
+        if ('' === $table || null === $uid) {
             return new JsonResponse(['error' => 'Expected a JSON body of shape {"table":"…","uid":1,"status":2|null}'], 400);
         }
 
-        $requestedStatus = null === $body['status'] ? null : (int) $body['status'];
+        $requestedStatus = null;
+        if (null !== $body['status']) {
+            $requestedStatus = $this->readPositiveInt($body['status']);
+            if (null === $requestedStatus) {
+                return new JsonResponse(['error' => 'Expected "status" to be a positive integer or null'], 400);
+            }
+        }
         $result = $this->statusChangeApiService->apply($table, $uid, $requestedStatus);
 
         return match ($result['outcome']) {
@@ -191,6 +199,32 @@ class ApiController
         }
 
         return $body;
+    }
+
+    /**
+     * Validates rather than casts, and returns null for anything that is not a positive
+     * integer reference.
+     *
+     * A cast is wrong here in both directions: `(int) "abc"` is 0, which the DataHandler
+     * reads as "unset the status" — a write the endpoint would then report as a failure,
+     * because normalizeStatus() maps 0 back to null and the outcome comparison fails. And
+     * `(int) "2abc"` is 2, so a malformed payload would silently change a record.
+     *
+     * Digit strings stay acceptable because readBody() also serves form-encoded bodies,
+     * where every value arrives as a string.
+     */
+    private function readPositiveInt(mixed $value): ?int
+    {
+        if (is_int($value)) {
+            return $value > 0 ? $value : null;
+        }
+
+        // ctype_digit() rejects "", "-1", "2abc" and " 2" — and, unlike is_numeric(), "2.0".
+        if (is_string($value) && ctype_digit($value)) {
+            return (int) $value > 0 ? (int) $value : null;
+        }
+
+        return null;
     }
 
     /**

--- a/Classes/Controller/ApiController.php
+++ b/Classes/Controller/ApiController.php
@@ -22,7 +22,6 @@ use Xima\XimaTypo3ContentPlanner\Utility\Security\PermissionUtility;
 use function array_key_exists;
 use function array_map;
 use function count;
-use function ctype_digit;
 use function is_array;
 use function is_int;
 use function is_string;
@@ -219,8 +218,10 @@ class ApiController
             return $value > 0 ? $value : null;
         }
 
-        // ctype_digit() rejects "", "-1", "2abc" and " 2" — and, unlike is_numeric(), "2.0".
-        if (is_string($value) && ctype_digit($value)) {
+        // Anchored, so "", "-1", "2abc", " 2" and "2.0" are all rejected. A regex rather
+        // than ctype_digit(), which would add ext-ctype to the extension's requirements
+        // for one check.
+        if (is_string($value) && 1 === preg_match('/^\d+$/', $value)) {
             return (int) $value > 0 ? (int) $value : null;
         }
 

--- a/Classes/Controller/ApiController.php
+++ b/Classes/Controller/ApiController.php
@@ -16,9 +16,10 @@ namespace Xima\XimaTypo3ContentPlanner\Controller;
 use Psr\Http\Message\{ResponseInterface, ServerRequestInterface};
 use TYPO3\CMS\Core\Http\JsonResponse;
 use Xima\XimaTypo3ContentPlanner\Domain\Model\Dto\Summary\RecordSummary;
-use Xima\XimaTypo3ContentPlanner\Service\{RecordSummaryService, StatusSelectionApiService};
+use Xima\XimaTypo3ContentPlanner\Service\{RecordSummaryService, ResultMessageService, StatusChangeApiService, StatusSelectionApiService};
 use Xima\XimaTypo3ContentPlanner\Utility\Security\PermissionUtility;
 
+use function array_key_exists;
 use function array_map;
 use function count;
 use function is_array;
@@ -41,7 +42,46 @@ class ApiController
     public function __construct(
         private readonly RecordSummaryService $recordSummaryService,
         private readonly StatusSelectionApiService $statusSelectionApiService,
+        private readonly StatusChangeApiService $statusChangeApiService,
+        private readonly ResultMessageService $resultMessageService,
     ) {}
+
+    /**
+     * Applies a status change through the DataHandler, so the result is indistinguishable
+     * from one made in the backend UI, and answers with the message the backend would
+     * show plus the record's fresh summary.
+     */
+    public function statusAction(ServerRequestInterface $request): ResponseInterface
+    {
+        if (!PermissionUtility::checkContentStatusVisibility()) {
+            return new JsonResponse(['error' => 'Content planner is not visible for this user'], 403);
+        }
+
+        $body = $this->readBody($request);
+        // "status" has to be present: a missing key is a malformed request, not a reset.
+        if (null === $body || !is_string($body['table'] ?? null) || !array_key_exists('status', $body)) {
+            return new JsonResponse(['error' => 'Expected a JSON body of shape {"table":"…","uid":1,"status":2|null}'], 400);
+        }
+
+        $table = $body['table'];
+        $uid = (int) ($body['uid'] ?? 0);
+        if ('' === $table || $uid <= 0) {
+            return new JsonResponse(['error' => 'Expected a JSON body of shape {"table":"…","uid":1,"status":2|null}'], 400);
+        }
+
+        $requestedStatus = null === $body['status'] ? null : (int) $body['status'];
+        $result = $this->statusChangeApiService->apply($table, $uid, $requestedStatus);
+
+        return match ($result['outcome']) {
+            StatusChangeApiService::OUTCOME_UNKNOWN_RECORD,
+            StatusChangeApiService::OUTCOME_TABLE_NOT_ALLOWED => new JsonResponse(
+                ['error' => 'Record not found or not accessible'],
+                404,
+            ),
+            StatusChangeApiService::OUTCOME_STRIPPED => $this->envelope($requestedStatus, 'failure', null, 403),
+            default => $this->envelope($requestedStatus, 'success', $this->summaryFor($table, $uid), 200),
+        };
+    }
 
     /**
      * Returns the statuses selectable for one record, filtered exactly as the backend
@@ -100,9 +140,46 @@ class ApiController
     }
 
     /**
-     * @return array<int, mixed>|null the raw item list, or null when the payload is unusable
+     * Builds the response for a status change: the message the backend would show, and on
+     * success the record's fresh summary so a consumer can re-render without a second call.
+     *
+     * `success` is supplied here rather than by MessageResult, because this is the layer
+     * that performed the write and therefore knows the outcome.
+     *
+     * @param array<string, mixed>|null $summary
      */
-    private function readItemList(ServerRequestInterface $request): ?array
+    private function envelope(?int $requestedStatus, string $resultStatus, ?array $summary, int $httpStatus): JsonResponse
+    {
+        $result = $this->resultMessageService->resolve(
+            null === $requestedStatus ? 'status.reset' : 'status.changed',
+            $resultStatus,
+        );
+
+        $payload = ['success' => 'success' === $resultStatus];
+        if (null !== $result) {
+            $payload += $result->toArray();
+        }
+        if (null !== $summary) {
+            $payload['record'] = $summary;
+        }
+
+        return new JsonResponse($payload, $httpStatus);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function summaryFor(string $table, int $uid): ?array
+    {
+        $summaries = $this->recordSummaryService->buildForItems([['table' => $table, 'uid' => $uid]]);
+
+        return [] === $summaries ? null : $summaries[0]->toArray();
+    }
+
+    /**
+     * @return array<string, mixed>|null the decoded JSON body, or null when unusable
+     */
+    private function readBody(ServerRequestInterface $request): ?array
     {
         $body = $request->getParsedBody();
 
@@ -112,6 +189,16 @@ class ApiController
             $decoded = json_decode((string) $request->getBody(), true);
             $body = is_array($decoded) ? $decoded : null;
         }
+
+        return $body;
+    }
+
+    /**
+     * @return array<int, mixed>|null the raw item list, or null when the payload is unusable
+     */
+    private function readItemList(ServerRequestInterface $request): ?array
+    {
+        $body = $this->readBody($request);
 
         if (null === $body || !isset($body['items']) || !is_array($body['items'])) {
             return null;

--- a/Classes/Service/StatusChangeApiService.php
+++ b/Classes/Service/StatusChangeApiService.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Service;
+
+use Doctrine\DBAL\Exception;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Xima\XimaTypo3ContentPlanner\Configuration;
+use Xima\XimaTypo3ContentPlanner\Domain\Repository\RecordRepository;
+use Xima\XimaTypo3ContentPlanner\Utility\ExtensionUtility;
+use Xima\XimaTypo3ContentPlanner\Utility\Security\PermissionUtility;
+
+use function is_array;
+
+/**
+ * StatusChangeApiService.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+class StatusChangeApiService
+{
+    /*
+     * Outcomes of a change attempt. "Stripped" is its own case because the pipeline
+     * silently drops the fields rather than reporting an error.
+     */
+    public const OUTCOME_APPLIED = 'applied';
+    public const OUTCOME_STRIPPED = 'stripped';
+    public const OUTCOME_UNKNOWN_RECORD = 'unknown-record';
+    public const OUTCOME_TABLE_NOT_ALLOWED = 'table-not-allowed';
+
+    public function __construct(private readonly RecordRepository $recordRepository) {}
+
+    /**
+     * Applies a status change through the DataHandler, so the whole backend pipeline runs:
+     * StatusChangeManager's permission stripping, the status reset handling, auto
+     * assignment, the comment relation sync and StatusChangeEvent. Writing the field
+     * directly would skip all of it and let the API drift from the backend.
+     *
+     * Whether the change took effect is decided by **re-reading the record**, not by
+     * re-implementing the permission checks: StatusChangeManager unsets the fields
+     * silently, so the only honest signal is what actually landed in the database.
+     *
+     * @return array{outcome: string, statusBefore: int|null, statusAfter: int|null}
+     *
+     * @throws Exception
+     */
+    public function apply(string $table, int $uid, ?int $requestedStatus): array
+    {
+        if (!$this->isTableUsable($table)) {
+            return ['outcome' => self::OUTCOME_TABLE_NOT_ALLOWED, 'statusBefore' => null, 'statusAfter' => null];
+        }
+
+        $record = $this->recordRepository->findByUid($table, $uid, ignoreVisibilityRestriction: true);
+        if (!is_array($record) || !$this->isRecordAccessible($table, $record)) {
+            return ['outcome' => self::OUTCOME_UNKNOWN_RECORD, 'statusBefore' => null, 'statusAfter' => null];
+        }
+
+        $before = $this->normalizeStatus($record[Configuration::FIELD_STATUS] ?? null);
+
+        $this->processDatamap($table, $uid, $requestedStatus);
+
+        $after = $this->currentStatus($table, $uid);
+
+        return [
+            'outcome' => $after === $requestedStatus ? self::OUTCOME_APPLIED : self::OUTCOME_STRIPPED,
+            'statusBefore' => $before,
+            'statusAfter' => $after,
+        ];
+    }
+
+    protected function isTableUsable(string $table): bool
+    {
+        return ExtensionUtility::isRegisteredRecordTable($table) && PermissionUtility::isTableAllowedForUser($table);
+    }
+
+    /**
+     * @param array<string, mixed> $record
+     */
+    protected function isRecordAccessible(string $table, array $record): bool
+    {
+        return PermissionUtility::checkAccessForRecord($table, $record);
+    }
+
+    protected function processDatamap(string $table, int $uid, ?int $requestedStatus): void
+    {
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start(
+            [$table => [$uid => [Configuration::FIELD_STATUS => $requestedStatus]]],
+            [],
+        );
+        $dataHandler->process_datamap();
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function currentStatus(string $table, int $uid): ?int
+    {
+        $record = $this->recordRepository->findByUid($table, $uid, ignoreVisibilityRestriction: true);
+
+        return is_array($record) ? $this->normalizeStatus($record[Configuration::FIELD_STATUS] ?? null) : null;
+    }
+
+    /**
+     * The field is nullable, but a reset can land as either NULL or 0 depending on the
+     * path taken, and both mean "no status".
+     */
+    private function normalizeStatus(mixed $value): ?int
+    {
+        if (null === $value || 0 === (int) $value) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+}

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -51,6 +51,11 @@ if (Xima\XimaTypo3ContentPlanner\Utility\ExtensionUtility::isFrontendApiEnabled(
         'methods' => ['POST'],
         'target' => Xima\XimaTypo3ContentPlanner\Controller\ApiController::class.'::summaryAction',
     ];
+    $routes['ximatypo3contentplanner_api_status'] = [
+        'path' => '/content-planner/api/status',
+        'methods' => ['POST'],
+        'target' => Xima\XimaTypo3ContentPlanner\Controller\ApiController::class.'::statusAction',
+    ];
     $routes['ximatypo3contentplanner_api_statusselection'] = [
         'path' => '/content-planner/api/status-selection',
         'methods' => ['GET'],

--- a/Documentation/DeveloperCorner/FrontendApi.rst
+++ b/Documentation/DeveloperCorner/FrontendApi.rst
@@ -202,6 +202,12 @@ Status change
 ``status: null`` unsets it. The key must be present — omitting it is a 400, not a
 reset.
 
+``table``, ``uid`` and ``status`` are **validated, not cast**. Anything that is not
+a positive integer — ``0``, ``"abc"``, ``"2abc"``, ``true``, ``2.5`` — is answered
+with 400 and changes nothing. A cast would make ``"abc"`` an implicit reset and
+``"2abc"`` a real status change. Digit strings such as ``"2"`` stay acceptable, so
+a form-encoded body keeps working.
+
 Response on success:
 
 ..  code-block:: json

--- a/Documentation/DeveloperCorner/FrontendApi.rst
+++ b/Documentation/DeveloperCorner/FrontendApi.rst
@@ -186,6 +186,63 @@ Capabilities
     follows from the visibility check applied to the whole request — if a record
     appears in ``items`` at all, its comments are readable.
 
+..  _frontend-api-status:
+
+Status change
+-------------
+
+..  code-block:: none
+
+    POST /content-planner/api/status
+
+..  code-block:: json
+
+    { "table": "pages", "uid": 12, "status": 2 }
+
+``status: null`` unsets it. The key must be present — omitting it is a 400, not a
+reset.
+
+Response on success:
+
+..  code-block:: json
+
+    {
+      "success": true,
+      "title": "Status changed",
+      "message": "The status of the record has been changed successfully.",
+      "severity": 0,
+      "record": { "table": "pages", "uid": 12, "status": { "…": "…" } }
+    }
+
+``record`` is the same shape as one item of the
+:ref:`annotation summary <frontend-api-summary>`, so a consumer can re-render a
+badge without a second request.
+
+Contract notes:
+
+It goes through the DataHandler
+    The change is applied with a data map, not by writing the field. That is what
+    makes it indistinguishable from a change made in the backend UI: permission
+    stripping, the status reset handling, auto assignment, the comment relation
+    sync and :ref:`StatusChangeEvent <events>` all run. A direct write would skip
+    every one of them.
+
+403 means the change was stripped
+    ``StatusChangeManager`` does not raise an error when a permission check fails
+    — it silently removes the fields. The endpoint therefore decides the outcome
+    by **re-reading the record** rather than by re-implementing the checks. When
+    the stored status does not match the requested one, the response is a 403
+    carrying the failure message and **no** ``record`` key.
+
+Wording follows the action
+    A change resolves ``status.changed``, a reset ``status.reset`` — the same
+    catalogue entries the backend flash messages use, so the frontend cannot drift
+    from the backend wording.
+
+404 hides existence
+    An unknown uid, an unregistered table and a record the user may not access all
+    answer 404, so the endpoint does not reveal which of the three applied.
+
 ..  _frontend-api-status-selection:
 
 Status selection

--- a/Tests/Functional/Controller/StatusChangeApiTest.php
+++ b/Tests/Functional/Controller/StatusChangeApiTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Tests\Functional\Controller;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\EventDispatcher\ListenerProvider;
+use TYPO3\CMS\Core\Http\{ServerRequest, StreamFactory};
+use Xima\XimaTypo3ContentPlanner\Configuration;
+use Xima\XimaTypo3ContentPlanner\Controller\ApiController;
+use Xima\XimaTypo3ContentPlanner\Domain\Repository\RecordRepository;
+use Xima\XimaTypo3ContentPlanner\Event\StatusChangeEvent;
+use Xima\XimaTypo3ContentPlanner\Service\{RecordSummaryService, ResultMessageService, StatusChangeApiService, StatusSelectionApiService};
+use Xima\XimaTypo3ContentPlanner\Tests\Functional\AbstractFunctionalTestCase;
+
+use function dirname;
+
+/**
+ * StatusChangeApiTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class StatusChangeApiTest extends AbstractFunctionalTestCase
+{
+    private ApiController $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importSharedDataSet('status.csv');
+        $this->importCSVDataSet(__DIR__.'/../Service/Fixtures/summary_pages.csv');
+        $this->loginBackendUser();
+        $this->setUpBackendRequest();
+        $this->subject = $this->get(ApiController::class);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY][Configuration::FEATURE_FRONTEND_API]);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function theRouteIsGatedByTheFlag(): void
+    {
+        self::assertArrayNotHasKey('ximatypo3contentplanner_api_status', $this->loadAjaxRoutes());
+
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY][Configuration::FEATURE_FRONTEND_API] = 1;
+        $routes = $this->loadAjaxRoutes();
+
+        self::assertSame('/content-planner/api/status', $routes['ximatypo3contentplanner_api_status']['path']);
+        self::assertSame(['POST'], $routes['ximatypo3contentplanner_api_status']['methods']);
+    }
+
+    #[Test]
+    public function writesTheStatusAndReportsTheFreshSummary(): void
+    {
+        // Fixture page 3 has no status.
+        $response = $this->subject->statusAction($this->bodyRequest(['table' => 'pages', 'uid' => 3, 'status' => 2]));
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = json_decode((string) $response->getBody(), true);
+
+        self::assertTrue($payload['success']);
+        self::assertSame(['success', 'title', 'message', 'severity', 'record'], array_keys($payload));
+        self::assertSame(2, $payload['record']['status']['uid']);
+        self::assertSame(2, $this->statusInDatabase(3), 'the DataHandler did not persist the status');
+    }
+
+    #[Test]
+    public function dispatchesTheStatusChangeEvent(): void
+    {
+        $spy = new class {
+            /** @var StatusChangeEvent[] */
+            public array $events = [];
+
+            public function __invoke(StatusChangeEvent $event): void
+            {
+                $this->events[] = $event;
+            }
+        };
+
+        $this->getContainer()->set('cp.test.status-change-spy', $spy);
+        $this->get(ListenerProvider::class)->addListener(
+            StatusChangeEvent::class,
+            'cp.test.status-change-spy',
+            '__invoke',
+        );
+
+        $this->subject->statusAction($this->bodyRequest(['table' => 'pages', 'uid' => 3, 'status' => 2]));
+
+        // StatusChangeManager dispatches this from inside the DataHandler pipeline. Writing
+        // the field directly would persist the status but never reach here.
+        self::assertCount(1, $spy->events);
+        self::assertSame('pages', $spy->events[0]->getTable());
+        self::assertSame(3, $spy->events[0]->getUid());
+        self::assertSame(2, $spy->events[0]->getNewStatus()?->getUid());
+        self::assertNull($spy->events[0]->getPreviousStatus());
+    }
+
+    #[Test]
+    public function unsetsTheStatusAndUsesTheResetWording(): void
+    {
+        // Fixture page 1 carries status 1.
+        $response = $this->subject->statusAction($this->bodyRequest(['table' => 'pages', 'uid' => 1, 'status' => null]));
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = json_decode((string) $response->getBody(), true);
+        self::assertTrue($payload['success']);
+        self::assertNull($payload['record']['status']);
+        self::assertNull($this->statusInDatabase(1));
+        // status.reset is a NOTICE, status.changed an OK — proves the wording branch.
+        self::assertSame(-2, $payload['severity']);
+    }
+
+    #[Test]
+    public function autoAssignmentFromTheBackendPipelineApplies(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY][Configuration::FEATURE_AUTO_ASSIGN] = 1;
+
+        $this->subject->statusAction($this->bodyRequest(['table' => 'pages', 'uid' => 3, 'status' => 2]));
+
+        $assignee = $this->getConnectionPool()->getConnectionForTable('pages')
+            ->select([Configuration::FIELD_ASSIGNEE], 'pages', ['uid' => 3])
+            ->fetchOne();
+
+        // Only the DataHandler path performs auto assignment, so a non-empty assignee is
+        // evidence the endpoint really went through it.
+        self::assertSame(1, (int) $assignee);
+
+        unset($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY][Configuration::FEATURE_AUTO_ASSIGN]);
+    }
+
+    #[Test]
+    public function reportsAStrippedChangeAsForbidden(): void
+    {
+        // StatusChangeManager silently unsets the fields when a permission check fails, so
+        // the endpoint detects it by re-reading rather than by re-implementing the checks.
+        // A pipeline that writes nothing reproduces exactly that shape.
+        $service = new class($this->get(RecordRepository::class)) extends StatusChangeApiService {
+            protected function processDatamap(string $table, int $uid, ?int $requestedStatus): void
+            {
+                // deliberately writes nothing, as a stripped change does
+            }
+        };
+
+        $controller = new ApiController(
+            $this->get(RecordSummaryService::class),
+            $this->get(StatusSelectionApiService::class),
+            $service,
+            $this->get(ResultMessageService::class),
+        );
+
+        $response = $controller->statusAction($this->bodyRequest(['table' => 'pages', 'uid' => 3, 'status' => 2]));
+
+        self::assertSame(403, $response->getStatusCode());
+        $payload = json_decode((string) $response->getBody(), true);
+        self::assertFalse($payload['success']);
+        self::assertSame(2, $payload['severity'], 'a stripped change must carry the ERROR severity');
+        self::assertArrayNotHasKey('record', $payload, 'no summary on a change that did not happen');
+        self::assertNull($this->statusInDatabase(3));
+    }
+
+    #[Test]
+    public function rejectsAnIncompletePayload(): void
+    {
+        self::assertSame(400, $this->subject->statusAction($this->bodyRequest(['uid' => 3, 'status' => 2]))->getStatusCode());
+        self::assertSame(400, $this->subject->statusAction($this->bodyRequest(['table' => 'pages', 'status' => 2]))->getStatusCode());
+        // A missing "status" key is not the same as an explicit null.
+        self::assertSame(400, $this->subject->statusAction($this->bodyRequest(['table' => 'pages', 'uid' => 3]))->getStatusCode());
+    }
+
+    #[Test]
+    public function returnsNotFoundForAnUnknownRecordAndAnUnregisteredTable(): void
+    {
+        self::assertSame(404, $this->subject->statusAction($this->bodyRequest(['table' => 'pages', 'uid' => 9999, 'status' => 2]))->getStatusCode());
+        self::assertSame(404, $this->subject->statusAction($this->bodyRequest(['table' => 'be_users', 'uid' => 1, 'status' => 2]))->getStatusCode());
+    }
+
+    private function statusInDatabase(int $uid): ?int
+    {
+        $value = $this->getConnectionPool()->getConnectionForTable('pages')
+            ->select([Configuration::FIELD_STATUS], 'pages', ['uid' => $uid])
+            ->fetchOne();
+
+        return null === $value || 0 === (int) $value ? null : (int) $value;
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    private function bodyRequest(array $body): ServerRequest
+    {
+        return (new ServerRequest('https://example.com/typo3/ajax/content-planner/api/status', 'POST'))
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->get(StreamFactory::class)->createStream((string) json_encode($body)));
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function loadAjaxRoutes(): array
+    {
+        return require dirname(__DIR__, 3).'/Configuration/Backend/AjaxRoutes.php';
+    }
+}

--- a/Tests/Functional/Controller/StatusChangeApiTest.php
+++ b/Tests/Functional/Controller/StatusChangeApiTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Xima\XimaTypo3ContentPlanner\Tests\Functional\Controller;
 
-use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\{DataProvider, Test};
 use TYPO3\CMS\Core\EventDispatcher\ListenerProvider;
 use TYPO3\CMS\Core\Http\{ServerRequest, StreamFactory};
 use Xima\XimaTypo3ContentPlanner\Configuration;
@@ -179,6 +179,65 @@ final class StatusChangeApiTest extends AbstractFunctionalTestCase
         self::assertSame(400, $this->subject->statusAction($this->bodyRequest(['table' => 'pages', 'status' => 2]))->getStatusCode());
         // A missing "status" key is not the same as an explicit null.
         self::assertSame(400, $this->subject->statusAction($this->bodyRequest(['table' => 'pages', 'uid' => 3]))->getStatusCode());
+    }
+
+    /**
+     * @param mixed $status the value sent as "status"
+     */
+    #[Test]
+    #[DataProvider('unusableStatusValues')]
+    public function rejectsAStatusThatIsNotAPositiveIntegerWithoutWriting(mixed $status): void
+    {
+        $before = $this->statusInDatabase(3);
+
+        $response = $this->subject->statusAction($this->bodyRequest(['table' => 'pages', 'uid' => 3, 'status' => $status]));
+
+        self::assertSame(400, $response->getStatusCode());
+        // The status code alone would not prove much: casting turns "abc" into 0, which the
+        // DataHandler applies as a reset before the endpoint reports a failure. What matters
+        // is that no write happened at all.
+        self::assertSame($before, $this->statusInDatabase(3), 'a rejected payload must not change the record');
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function unusableStatusValues(): array
+    {
+        return [
+            // Cast to 0, i.e. an implicit reset the caller never asked for.
+            'zero' => [0],
+            'non-numeric string' => ['abc'],
+            'false' => [false],
+            // Cast to a valid status uid, i.e. a silent change from a malformed payload.
+            'numeric prefix' => ['2abc'],
+            'true' => [true],
+            'negative' => [-1],
+            'float' => [2.5],
+            'array' => [[2]],
+        ];
+    }
+
+    #[Test]
+    public function stillAcceptsADigitStringSoFormEncodedBodiesKeepWorking(): void
+    {
+        // readBody() also serves form-encoded bodies, where every value is a string.
+        $response = $this->subject->statusAction($this->bodyRequest(['table' => 'pages', 'uid' => '3', 'status' => '2']));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(2, $this->statusInDatabase(3));
+    }
+
+    #[Test]
+    public function rejectsAUidThatIsNotAPositiveIntegerWithoutWriting(): void
+    {
+        // Same defect class as the status above: a cast would target record 3 here.
+        $before = $this->statusInDatabase(3);
+
+        $response = $this->subject->statusAction($this->bodyRequest(['table' => 'pages', 'uid' => '3abc', 'status' => 2]));
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertSame($before, $this->statusInDatabase(3));
     }
 
     #[Test]


### PR DESCRIPTION
Implements #279 (CP-3). Targets `main`, which now carries CP-2, CP-5 and CP-7.

## Endpoint

```
POST /content-planner/api/status
{ "table": "pages", "uid": 12, "status": 2 }
```

`status: null` unsets. The key must be **present** — omitting it is a 400, not a reset.

Success returns the CP-2 message envelope plus the record's fresh summary in the CP-5 item shape, so a consumer can re-render a badge without a second call:

```json
{ "success": true, "title": "Status changed", "message": "…", "severity": 0, "record": { … } }
```

## It goes through the DataHandler, and the tests prove it

The change is applied with a data map, never by writing the field. That is what makes it indistinguishable from a backend change: permission stripping, status reset handling, auto assignment, the comment relation sync and `StatusChangeEvent` all run.

Claiming that is easy; I checked it. Temporarily swapping `processDatamap()` for a raw `updateStatusByUid()` call makes exactly two tests fail while a third keeps passing:

| test | raw write | DataHandler |
|---|---|---|
| `writesTheStatusAndReportsTheFreshSummary` | **passes** | passes |
| `dispatchesTheStatusChangeEvent` | fails (0 events) | passes |
| `autoAssignmentFromTheBackendPipelineApplies` | fails (assignee 0) | passes |

So the suite genuinely discriminates the pipeline from a direct write — which is the specific regression #279 warns about. The event test registers a real spy in the container and asserts the event's table, uid, new status and previous status, rather than inferring dispatch from a side effect.

## How 403 is decided

`StatusChangeManager` does not raise an error when a permission check fails — it silently `unset()`s the fields. So the endpoint **re-reads the record** and compares the stored status with the requested one, rather than re-implementing the permission matrix. That keeps a single source of truth: if the pipeline's rules change, the endpoint follows automatically.

A stripped change answers 403 with the failure wording and **no** `record` key. `reportsAStrippedChangeAsForbidden` exercises it with a subclass whose `processDatamap()` writes nothing, reproducing exactly the shape a stripped change produces.

## Wording

A change resolves `status.changed`, a reset `status.reset` — the same catalogue entries the backend flash messages use, via CP-2's service. `unsetsTheStatusAndUsesTheResetWording` asserts severity `-2` (NOTICE) for the reset against `0` (OK) for a change, which pins the branch.

`success` is supplied by the controller, not by `MessageResult`: this is the layer that performed the write and therefore knows the outcome. That is the split agreed in #291.

## Test plan

- [x] 8 functional tests: route gating both directions, the write plus fresh summary, event dispatch with a real listener, reset wording, auto assignment, the 403 stripped path, payload validation (including missing-vs-null `status`), and 404 for unknown record / unregistered table
- [x] Full suite: 412 tests, 728 assertions, 0 failures (3 pre-existing v14-only skips)
- [x] PHPStan level 6, `php-cs-fixer` and the Rector dry-run all clean; doc references resolve
- [ ] Manual check against a real record with the flag on, comparing the resulting DB state and history entry to a change made through the backend dropdown

## Note

While writing this I briefly edited `RecordRepository.php` on this branch by mistake — those edits belonged to #294's review and have been reverted here and moved. This branch touches no caching code; the 412-test run above is from the clean state after that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an API endpoint for updating or resetting record statuses.
  - Supports permission checks, validation, automatic status assignment, and clear result messages.
  - Returns updated record information and appropriate responses for invalid, unauthorized, or unknown requests.
  - Added a feature-controlled backend route for the status endpoint.

- **Documentation**
  - Documented request and response formats, status resets, permissions, and error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->