### PR TITLE
feat: add an embeddable standalone comments view (#277)

### DIFF
--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -61,6 +61,13 @@ class Configuration
     final public const TREE_LABEL_PRIORITY_STATUS = 100;
     final public const TREE_LABEL_PRIORITY_EMPTY = -2;
 
+    /**
+     * Path of the embeddable comments view route. Registered in Configuration/Backend/Routes.php
+     * and recognised again in ModifyButtonBarEventListener, which has to tell the view's
+     * link-based edit flow apart from the JavaScript-driven backend modal.
+     */
+    final public const ROUTE_PATH_COMMENTS_VIEW = '/content-planner/comments/view';
+
     final public const TABLE_FOLDER = 'tx_ximatypo3contentplanner_folder';
     final public const TABLE_COMMENT = 'tx_ximatypo3contentplanner_comment';
     final public const TABLE_STATUS = 'tx_ximatypo3contentplanner_status';

--- a/Classes/Controller/CommentsViewController.php
+++ b/Classes/Controller/CommentsViewController.php
@@ -165,6 +165,11 @@ class CommentsViewController
             // Embedded or not, this is backend content and has no business in an index.
             '<meta name="robots" content="noindex, nofollow">',
             '<title>'.htmlspecialchars($title, \ENT_QUOTES).'</title>',
+            // Without this the browser requests /favicon.ico on every load and gets a 404.
+            '<link rel="icon" href="'.htmlspecialchars(
+                AssetUtility::getPublicResourcePath('EXT:backend/Resources/Public/Icons/favicon.ico'),
+                \ENT_QUOTES,
+            ).'">',
             $this->cssTags($request),
             '</head>',
             '<body>',

--- a/Classes/Controller/CommentsViewController.php
+++ b/Classes/Controller/CommentsViewController.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Controller;
+
+use Psr\Http\Message\{ResponseInterface, ServerRequestInterface};
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Http\HtmlResponse;
+use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Xima\XimaTypo3ContentPlanner\Configuration;
+use Xima\XimaTypo3ContentPlanner\Domain\Repository\{CommentRepository, RecordRepository};
+use Xima\XimaTypo3ContentPlanner\Utility\Rendering\{AssetUtility, ViewUtility};
+use Xima\XimaTypo3ContentPlanner\Utility\Routing\UrlUtility;
+use Xima\XimaTypo3ContentPlanner\Utility\Security\PermissionUtility;
+
+use function htmlspecialchars;
+use function implode;
+use function in_array;
+use function sprintf;
+
+/**
+ * CommentsViewController.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+class CommentsViewController
+{
+    private const SORT_DIRECTIONS = ['ASC', 'DESC'];
+
+    public function __construct(
+        private readonly RecordRepository $recordRepository,
+        private readonly CommentRepository $commentRepository,
+    ) {}
+
+    /**
+     * The route is only registered while the embeddable comments view is enabled, so
+     * reaching this action already implies the feature flag, a backend session and a valid
+     * route token. The content planner's own permission checks still run here — they are
+     * the same ones RecordController::commentsAction() applies.
+     */
+    public function indexAction(ServerRequestInterface $request): ResponseInterface
+    {
+        $table = (string) ($request->getQueryParams()['table'] ?? '');
+        $uid = (int) ($request->getQueryParams()['uid'] ?? 0);
+
+        if ('' === $table || $uid <= 0) {
+            return $this->errorResponse('Both a table and a uid are required', 400);
+        }
+
+        if (!PermissionUtility::checkContentStatusVisibility()) {
+            return $this->errorResponse('Content planner is not visible for this user', 403);
+        }
+
+        // Truthiness, not a null check: findByUid() returns null for a table the content
+        // planner does not track and false for a missing row.
+        $record = $this->recordRepository->findByUid($table, $uid, ignoreVisibilityRestriction: true);
+        if (!$record) {
+            return $this->errorResponse('Record not found', 404);
+        }
+
+        if (!PermissionUtility::checkAccessForRecord($table, $record)) {
+            return $this->errorResponse('Access denied', 403);
+        }
+
+        return new HtmlResponse($this->renderDocument($request, $table, $uid, $record));
+    }
+
+    /**
+     * @param array<string, mixed> $record
+     */
+    private function renderDocument(ServerRequestInterface $request, string $table, int $uid, array $record): string
+    {
+        $sortComments = (string) ($request->getQueryParams()['sortComments'] ?? 'DESC');
+        if (!in_array($sortComments, self::SORT_DIRECTIONS, true)) {
+            $sortComments = 'DESC';
+        }
+        $showResolvedComments = (bool) ($request->getQueryParams()['showResolvedComments'] ?? false);
+
+        $comments = $this->commentRepository->findAllByRecord(
+            $uid,
+            $table,
+            sortDirection: $sortComments,
+            showResolved: $showResolvedComments,
+        );
+
+        $content = ViewUtility::render(
+            'Default/CommentsView.html',
+            [
+                'comments' => $comments,
+                'id' => $uid,
+                'table' => $table,
+                'newCommentUri' => PermissionUtility::canCreateComment() ? UrlUtility::getNewCommentUrl($table, $uid) : '',
+                'shareUrl' => UrlUtility::getShareUrl($table, $uid),
+                'recordUri' => UrlUtility::getRecordLink(
+                    $table,
+                    $uid,
+                    isset($record['folder_identifier']) ? (string) $record['folder_identifier'] : null,
+                ),
+                'filter' => [
+                    'sortComments' => $sortComments,
+                    'showResolvedComments' => $showResolvedComments,
+                    'resolvedCount' => $this->commentRepository->countAllByRecord($uid, $table, onlyResolved: true),
+                    // The view carries no JavaScript, so the filter toggles are links that
+                    // reload it with the flipped value instead of a submitting form.
+                    'sortUri' => UrlUtility::getCommentsViewUrl($table, $uid, [
+                        'sortComments' => 'DESC' === $sortComments ? 'ASC' : 'DESC',
+                        'showResolvedComments' => $showResolvedComments ? 1 : 0,
+                    ]),
+                    'toggleResolvedUri' => UrlUtility::getCommentsViewUrl($table, $uid, [
+                        'sortComments' => $sortComments,
+                        'showResolvedComments' => $showResolvedComments ? 0 : 1,
+                    ]),
+                ],
+            ],
+        );
+
+        return $this->renderPage($request, $content);
+    }
+
+    /**
+     * Assembles the document by hand instead of going through the PageRenderer.
+     *
+     * PageRenderer::render() unconditionally inlines TYPO3.settings for backend requests,
+     * and that object holds a URL *including its CSRF token* for every registered backend
+     * AJAX route. Handing that to a document whose whole purpose is to be embedded by
+     * another page is not acceptable: where the embedder is same-origin — a frontend on the
+     * same host, which is the motivating case for this view — it can simply read
+     * frame.contentWindow.TYPO3.settings and walk away with every backend token.
+     *
+     * What we give up is PageRenderer's <html> attribute handling, so the theme and colour
+     * scheme resolution below deliberately mirrors PageRenderer::setDefaultHtmlTag().
+     */
+    private function renderPage(ServerRequestInterface $request, string $content): string
+    {
+        $languageService = $this->getLanguageService();
+        $title = $languageService->sL(
+            'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang.xlf:comment.view.title',
+        );
+
+        return implode("\n", [
+            '<!DOCTYPE html>',
+            '<html '.GeneralUtility::implodeAttributes($this->htmlTagAttributes($languageService), true).'>',
+            '<head>',
+            '<meta charset="utf-8">',
+            '<meta name="viewport" content="width=device-width, initial-scale=1">',
+            // Embedded or not, this is backend content and has no business in an index.
+            '<meta name="robots" content="noindex, nofollow">',
+            '<title>'.htmlspecialchars($title, \ENT_QUOTES).'</title>',
+            $this->cssTags($request),
+            '</head>',
+            '<body>',
+            $content,
+            '</body>',
+            '</html>',
+        ]);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function htmlTagAttributes(LanguageService $languageService): array
+    {
+        $locale = $languageService->getLocale();
+        $attributes = ['lang' => $locale->getName()];
+        if ($locale->isRightToLeftLanguageDirection()) {
+            $attributes['dir'] = 'rtl';
+        }
+
+        $backendUser = $this->getBackendUser();
+        if (null === $backendUser) {
+            return $attributes;
+        }
+
+        // backend.css keys its dark variables off these attributes, so the embedded view
+        // follows the same user preference the backend itself does.
+        $userTsConfig = $backendUser->getTSConfig();
+
+        $theme = (string) ($backendUser->uc['theme'] ?? $userTsConfig['setup.']['fields.']['theme'] ?? 'auto');
+        if ('1' === ($userTsConfig['setup.']['fields.']['theme.']['disabled'] ?? '0')) {
+            $theme = (string) ($userTsConfig['setup.']['fields.']['theme'] ?? 'modern');
+        }
+        if ('modern' !== $theme) {
+            $attributes['data-theme'] = $theme;
+        }
+
+        $colorScheme = (string) ($backendUser->uc['colorScheme'] ?? $userTsConfig['setup.']['fields.']['colorScheme'] ?? 'auto');
+        if ('1' === ($userTsConfig['setup.']['fields.']['colorScheme.']['disabled'] ?? '0')) {
+            $colorScheme = (string) ($userTsConfig['setup.']['fields.']['colorScheme'] ?? 'light');
+        }
+        if ('auto' !== $colorScheme) {
+            $attributes['data-color-scheme'] = $colorScheme;
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * backend.css carries the Bootstrap layer the comment markup and Comments.css are
+     * written against (.btn, .badge, --bs-* custom properties). Without it the thread
+     * renders unstyled, which is precisely what the embedding page must not have to fix.
+     */
+    private function cssTags(ServerRequestInterface $request): string
+    {
+        $nonce = $request->getAttribute('nonce');
+        $attributes = null === $nonce ? [] : ['nonce' => (string) $nonce];
+
+        $tags = [];
+        foreach ([
+            'EXT:backend/Resources/Public/Css/backend.css',
+            'EXT:'.Configuration::EXT_KEY.'/Resources/Public/Css/Comments.css',
+            'EXT:'.Configuration::EXT_KEY.'/Resources/Public/Css/CommentsView.css',
+        ] as $file) {
+            $tags[] = AssetUtility::getCssTag($file, $attributes);
+        }
+
+        return implode("\n", $tags);
+    }
+
+    private function getBackendUser(): ?BackendUserAuthentication
+    {
+        $backendUser = $GLOBALS['BE_USER'] ?? null;
+
+        return $backendUser instanceof BackendUserAuthentication ? $backendUser : null;
+    }
+
+    /**
+     * A document route answers with a document, including when it refuses. The message is
+     * intentionally terse — it is shown inside somebody else's iframe.
+     */
+    private function errorResponse(string $message, int $status): HtmlResponse
+    {
+        $body = sprintf(
+            '<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>%1$s</title></head><body><p>%1$s</p></body></html>',
+            htmlspecialchars($message, \ENT_QUOTES),
+        );
+
+        return new HtmlResponse($body, $status);
+    }
+
+    private function getLanguageService(): LanguageService
+    {
+        return $GLOBALS['LANG'];
+    }
+}

--- a/Classes/Controller/CommentsViewController.php
+++ b/Classes/Controller/CommentsViewController.php
@@ -134,10 +134,17 @@ class CommentsViewController
      *
      * PageRenderer::render() unconditionally inlines TYPO3.settings for backend requests,
      * and that object holds a URL *including its CSRF token* for every registered backend
-     * AJAX route. Handing that to a document whose whole purpose is to be embedded by
-     * another page is not acceptable: where the embedder is same-origin — a frontend on the
-     * same host, which is the motivating case for this view — it can simply read
-     * frame.contentWindow.TYPO3.settings and walk away with every backend token.
+     * AJAX route. This view needs none of them, and a response built to be handed to other
+     * contexts should carry as little as it can — it may end up in a cache, a proxy log or
+     * a screenshot in a bug report.
+     *
+     * This is blast radius, not an exploit: a cross-origin embedder can read neither the
+     * frame's DOM nor its globals, and a same-origin embedder already holds the backend
+     * session and could fetch any token it wanted. What it buys is that the document stops
+     * carrying the whole backend surface when it only ever needed a handful of routes.
+     *
+     * Those remaining routes are still token-bearing — the action links would not work
+     * otherwise — so the document is smaller in exposure, not free of it.
      *
      * What we give up is PageRenderer's <html> attribute handling, so the theme and colour
      * scheme resolution below deliberately mirrors PageRenderer::setDefaultHtmlTag().

--- a/Classes/EventListener/ModifyButtonBarEventListener.php
+++ b/Classes/EventListener/ModifyButtonBarEventListener.php
@@ -15,7 +15,6 @@ namespace Xima\XimaTypo3ContentPlanner\EventListener;
 
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Module\ModuleInterface;
-use TYPO3\CMS\Backend\Template\Components\Buttons\InputButton;
 use TYPO3\CMS\Backend\Template\Components\ModifyButtonBarEvent;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
 use TYPO3\CMS\Core\Imaging\IconFactory;
@@ -23,12 +22,14 @@ use TYPO3\CMS\Core\Localization\LanguageService;
 use Xima\XimaTypo3ContentPlanner\Configuration;
 use Xima\XimaTypo3ContentPlanner\Domain\Model\Status;
 use Xima\XimaTypo3ContentPlanner\Domain\Repository\{FolderStatusRepository, RecordRepository, StatusRepository};
+use Xima\XimaTypo3ContentPlanner\Service\ButtonBar\CommentFormButtonPolicy;
 use Xima\XimaTypo3ContentPlanner\Service\SelectionBuilder\DropDownSelectionService;
 use Xima\XimaTypo3ContentPlanner\Utility\Compatibility\{ComponentFactoryUtility, RouteUtility};
 use Xima\XimaTypo3ContentPlanner\Utility\ExtensionUtility;
 use Xima\XimaTypo3ContentPlanner\Utility\Security\PermissionUtility;
 
 use function is_array;
+use function str_contains;
 
 /**
  * ModifyButtonBarEventListener.
@@ -45,6 +46,7 @@ final readonly class ModifyButtonBarEventListener
         private RecordRepository $recordRepository,
         private DropDownSelectionService $dropDownSelectionService,
         private FolderStatusRepository $folderStatusRepository,
+        private CommentFormButtonPolicy $commentFormButtonPolicy,
     ) {}
 
     public function __invoke(ModifyButtonBarEvent $event): void
@@ -73,7 +75,7 @@ final readonly class ModifyButtonBarEventListener
         }
 
         if (Configuration::TABLE_COMMENT === $table) {
-            $this->removeButtonsExceptSave($event);
+            $this->removeButtonsExceptSave($event, $this->isEmbeddedCommentsViewFlow($request));
 
             return;
         }
@@ -167,23 +169,31 @@ final readonly class ModifyButtonBarEventListener
         return $this->statusRepository->findByUid($record[Configuration::FIELD_STATUS]);
     }
 
-    private function removeButtonsExceptSave(ModifyButtonBarEvent $event): void
+    /**
+     * Strips the comment edit form down to its save button, because the backend modal
+     * supplies its own close control.
+     *
+     * The embeddable comments view is the exception. It reaches the same form through a
+     * plain link with a returnUrl, so nothing is going to close the form for it: keeping
+     * only the save button would leave the user stranded in the form with no way back.
+     * There the core close button stays, and the save button keeps its own label — calling
+     * it "Save and Close" is only true while the modal is the one doing the closing.
+     */
+    private function removeButtonsExceptSave(ModifyButtonBarEvent $event, bool $keepCloseButton = false): void
     {
-        $buttons = [];
+        $event->setButtons($this->commentFormButtonPolicy->apply($event->getButtons(), $keepCloseButton));
+    }
 
-        foreach ($event->getButtons() as $position => $buttonGroup) {
-            if ('right' === $position) {
-                continue;
-            }
-            foreach ($buttonGroup as $button) {
-                if ($button[0] instanceof InputButton && str_contains($button[0]->getName(), '_save')) {
-                    $button[0]->setTitle($this->getLanguageService()->sL('LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:save_and_close'));
+    /**
+     * True when the comment form was opened from the embeddable comments view, which is
+     * recognisable by the returnUrl it sends along. Present on the GET that renders the form
+     * and, through the form action, on the save that follows.
+     */
+    private function isEmbeddedCommentsViewFlow(ServerRequestInterface $request): bool
+    {
+        $returnUrl = (string) ($request->getQueryParams()['returnUrl'] ?? '');
 
-                    $buttons[$position][] = $button;
-                }
-            }
-        }
-        $event->setButtons($buttons);
+        return str_contains($returnUrl, Configuration::ROUTE_PATH_COMMENTS_VIEW);
     }
 
     private function isFileListModule(ServerRequestInterface $request): bool

--- a/Classes/Service/ButtonBar/CommentFormButtonPolicy.php
+++ b/Classes/Service/ButtonBar/CommentFormButtonPolicy.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Service\ButtonBar;
+
+use TYPO3\CMS\Backend\Template\Components\Buttons\{InputButton, LinkButton};
+use TYPO3\CMS\Core\Localization\LanguageService;
+use Xima\XimaTypo3ContentPlanner\Configuration;
+
+use function is_array;
+use function str_contains;
+
+/**
+ * CommentFormButtonPolicy.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class CommentFormButtonPolicy
+{
+    /**
+     * Class core puts on the close button, which it registers as a link button. The form
+     * engine binds the click handler that navigates to the returnUrl.
+     */
+    private const CLOSE_BUTTON_CLASS = 't3js-editform-close';
+
+    /**
+     * @param array<string, array<int, mixed>> $buttons
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    public function apply(array $buttons, bool $keepCloseButton): array
+    {
+        $result = [];
+
+        foreach ($buttons as $position => $group) {
+            if ('right' === $position) {
+                continue;
+            }
+
+            $kept = $this->filterGroup($group, $keepCloseButton);
+            if ([] !== $kept) {
+                $result[$position] = $kept;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<int, mixed> $group
+     *
+     * @return array<int, mixed>
+     */
+    private function filterGroup(array $group, bool $keepCloseButton): array
+    {
+        $kept = [];
+
+        foreach ($group as $button) {
+            $candidate = is_array($button) ? ($button[0] ?? null) : null;
+
+            if ($this->isSaveButton($candidate)) {
+                $this->labelSaveButton($candidate, $keepCloseButton);
+                $kept[] = $button;
+            } elseif ($keepCloseButton && $this->isCloseButton($candidate)) {
+                $kept[] = $button;
+            }
+        }
+
+        return $kept;
+    }
+
+    private function isSaveButton(mixed $button): bool
+    {
+        return $button instanceof InputButton && str_contains($button->getName(), '_save');
+    }
+
+    private function isCloseButton(mixed $button): bool
+    {
+        return $button instanceof LinkButton && str_contains($button->getClasses(), self::CLOSE_BUTTON_CLASS);
+    }
+
+    private function labelSaveButton(mixed $button, bool $keepCloseButton): void
+    {
+        if ($keepCloseButton || !$button instanceof InputButton) {
+            return;
+        }
+
+        $button->setTitle($this->getLanguageService()->sL(
+            'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang_be.xlf:save_and_close',
+        ));
+    }
+
+    private function getLanguageService(): LanguageService
+    {
+        return $GLOBALS['LANG'];
+    }
+}

--- a/Classes/Utility/Routing/UrlUtility.php
+++ b/Classes/Utility/Routing/UrlUtility.php
@@ -177,6 +177,23 @@ class UrlUtility
     }
 
     /**
+     * URL of the embeddable comments view. Also the target a consumer embeds, so it is
+     * built here rather than in the controller.
+     *
+     * The view renders no JavaScript, so its filter is a set of links rather than a
+     * submitting form — hence $extraParams, which carries the filter state.
+     *
+     * @param array<string, mixed> $extraParams
+     *
+     * @throws RouteNotFoundException
+     */
+    public static function getCommentsViewUrl(string $table, int $uid, array $extraParams = []): string
+    {
+        return (string) GeneralUtility::makeInstance(UriBuilder::class)
+            ->buildUriFromRoute('ximatypo3contentplanner_comments_view', ['table' => $table, 'uid' => $uid, ...$extraParams]);
+    }
+
+    /**
      * @throws RouteNotFoundException
      */
     public static function getShareUrl(string $table, int $uid, ?int $commentUid = null): string

--- a/Configuration/Backend/Routes.php
+++ b/Configuration/Backend/Routes.php
@@ -34,7 +34,7 @@ $routes = [
 // expired" by status code alone.
 if (Xima\XimaTypo3ContentPlanner\Utility\ExtensionUtility::isEmbeddableCommentsViewEnabled()) {
     $routes['ximatypo3contentplanner_comments_view'] = [
-        'path' => '/content-planner/comments/view',
+        'path' => Xima\XimaTypo3ContentPlanner\Configuration::ROUTE_PATH_COMMENTS_VIEW,
         'target' => Xima\XimaTypo3ContentPlanner\Controller\CommentsViewController::class.'::indexAction',
     ];
 }

--- a/Configuration/Backend/Routes.php
+++ b/Configuration/Backend/Routes.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-return [
+$routes = [
     'ximatypo3contentplanner_message' => [
         'path' => '/content-planner/message',
         'access' => 'public',
@@ -27,3 +27,16 @@ return [
         'target' => Xima\XimaTypo3ContentPlanner\Controller\RecordController::class.'::shareAction',
     ],
 ];
+
+// Not registered at all while the feature flag is off, so no guard is needed in the action
+// itself. Note that an unregistered backend route is answered with a redirect to the
+// backend shell rather than a 404, so a consumer cannot tell "disabled" from "session
+// expired" by status code alone.
+if (Xima\XimaTypo3ContentPlanner\Utility\ExtensionUtility::isEmbeddableCommentsViewEnabled()) {
+    $routes['ximatypo3contentplanner_comments_view'] = [
+        'path' => '/content-planner/comments/view',
+        'target' => Xima\XimaTypo3ContentPlanner\Controller\CommentsViewController::class.'::indexAction',
+    ];
+}
+
+return $routes;

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -46,6 +46,9 @@ services:
   Xima\XimaTypo3ContentPlanner\Controller\ApiController:
     public: true
 
+  Xima\XimaTypo3ContentPlanner\Controller\CommentsViewController:
+    public: true
+
   Xima\XimaTypo3ContentPlanner\Service\Header\InfoGenerator:
     public: true
 

--- a/Documentation/DeveloperCorner/FrontendApi.rst
+++ b/Documentation/DeveloperCorner/FrontendApi.rst
@@ -74,10 +74,6 @@ configuration keeps the endpoints disabled.
 Endpoints
 =========
 
-..  note::
-    Endpoint contracts are documented alongside their implementation. This
-    section grows as the individual endpoints land.
-
 Routes are registered only while their flag is on, so a disabled endpoint does
 not exist in the route collection at all.
 
@@ -248,6 +244,76 @@ The current status is included
 ``canUnset``
     True only when the record actually has a status *and* the user holds the
     unset permission. It is independent of the selection listener.
+
+..  _frontend-api-comments-view:
+
+Embeddable comments view
+------------------------
+
+..  code-block:: none
+
+    GET /content-planner/comments/view?table=pages&uid=12
+
+Renders the comment thread of one record as a **complete HTML document**, suitable as the
+``src`` of an ``<iframe>``. Unlike the endpoints above this is gated by
+:ref:`enableEmbeddableCommentsView <extconf-enableEmbeddableCommentsView>`, and it answers
+with a document rather than JSON — including when it refuses, since the response is going
+to be displayed in somebody else's frame. Refusals mirror the backend's own comment
+endpoint: ``400`` without both parameters, ``403`` when the content planner is not visible
+for the user, ``404`` for a record that does not exist or is not tracked.
+
+Optional query parameters ``sortComments`` (``ASC``/``DESC``) and ``showResolvedComments``
+(``0``/``1``) carry the filter state; the view's own filter controls are links that reload
+it with the flipped value.
+
+Contract notes:
+
+Self-contained, and carrying no JavaScript
+    The document brings its own stylesheets — the backend's ``backend.css`` plus the
+    content planner's comment styles — so the embedding page needs no backend assets. It
+    ships **no JavaScript at all**, which is a deliberate constraint rather than an
+    omission: an embedded frame's ``top`` window belongs to the consumer, so nothing may
+    depend on ``top.TYPO3``, on ``TYPO3.settings`` or on the backend's modal machinery.
+
+    ..  important::
+        For the same reason the view does not use ``PageRenderer``. Rendering a backend
+        document through it inlines ``TYPO3.settings``, which contains a URL *including its
+        CSRF token* for every registered backend AJAX route. In a document meant to be
+        embedded that is a token-disclosure risk — a same-origin embedder can read
+        ``frame.contentWindow.TYPO3.settings`` directly. The view therefore assembles its
+        own document and mirrors only the ``<html>`` attributes (language, direction, theme,
+        colour scheme) that the backend styling depends on.
+
+Dark and light follow the backend user
+    The colour scheme is taken from the backend user's own preference, the same way the
+    backend resolves it. With the preference left on *auto* no attribute is emitted and the
+    document follows ``prefers-color-scheme``.
+
+Actions are link round-trips
+    Creating, editing and replying keep using ``record_edit`` — so the RTE and every TCA
+    field behave exactly as in the backend — and navigate **inside the frame**, returning to
+    the view through ``returnUrl``. Resolving works the same way through ``tce_db``.
+
+Links that leave the thread open outside the frame
+    The share link and the record link would replace the frame with a full backend page, so
+    both carry ``target="_top"``.
+
+Deleting is not offered here
+    A delete link cannot ask for confirmation without JavaScript, and a single click that
+    irreversibly removes a comment is worse than not offering it. Use the record link to
+    reach the backend, where deletion keeps its confirmation step.
+
+..  warning::
+    **Embedding works same-origin out of the box; cross-origin does not.** The view is a
+    backend route and needs the backend session cookie, which TYPO3 issues with
+    ``SameSite=strict`` by default — a browser does not send it to an ``<iframe>`` on a
+    different origin, so the frame ends up at the login screen instead.
+
+    Embedding a frontend on the same host as the backend — the motivating case — is
+    unaffected. Embedding from a different origin requires
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['cookieSameSite'] = 'none'` (which also demands
+    ``Secure``). Weigh that against its CSRF implications before changing it; it is a
+    site-wide decision, not one this view can make.
 
 Checking a flag
 ===============

--- a/Documentation/DeveloperCorner/FrontendApi.rst
+++ b/Documentation/DeveloperCorner/FrontendApi.rst
@@ -278,11 +278,22 @@ Self-contained, and carrying no JavaScript
     ..  important::
         For the same reason the view does not use ``PageRenderer``. Rendering a backend
         document through it inlines ``TYPO3.settings``, which contains a URL *including its
-        CSRF token* for every registered backend AJAX route. In a document meant to be
-        embedded that is a token-disclosure risk — a same-origin embedder can read
-        ``frame.contentWindow.TYPO3.settings`` directly. The view therefore assembles its
-        own document and mirrors only the ``<html>`` attributes (language, direction, theme,
-        colour scheme) that the backend styling depends on.
+        CSRF token* for every registered backend AJAX route. This view needs none of them,
+        so it assembles its own document and mirrors only the ``<html>`` attributes
+        (language, direction, theme, colour scheme) that the backend styling depends on.
+
+..  note::
+    **The document is not token-free, and it is not meant to be.** The comment actions
+    are ``record_edit`` and ``tce_db`` links, and a backend route link carries a route
+    token by construction — removing it would remove the action. Avoiding ``PageRenderer``
+    narrows what the document exposes from *every* backend AJAX route to the handful this
+    view actually offers; it does not eliminate exposure.
+
+    Treat that as reducing blast radius rather than closing a hole. A cross-origin
+    embedder can read neither the frame's DOM nor its globals, and a same-origin embedder
+    already holds the backend session and could fetch any token it wanted — so neither
+    case is an escalation. The reason to keep the surface small is everything else a
+    response passes through: caches, proxy logs, browser history, screenshots.
 
 Dark and light follow the backend user
     The colour scheme is taken from the backend user's own preference, the same way the

--- a/Documentation/DeveloperCorner/FrontendApi.rst
+++ b/Documentation/DeveloperCorner/FrontendApi.rst
@@ -303,7 +303,14 @@ Dark and light follow the backend user
 Actions are link round-trips
     Creating, editing and replying keep using ``record_edit`` — so the RTE and every TCA
     field behave exactly as in the backend — and navigate **inside the frame**, returning to
-    the view through ``returnUrl``. Resolving works the same way through ``tce_db``.
+    the view through ``returnUrl``. Resolving goes through ``tce_db``, which redirects back
+    on its own.
+
+    In the edit form the user saves and then closes, which is the plain backend flow: the
+    core :guilabel:`Close` button is what follows the ``returnUrl``. The backend modal
+    normally has that button removed, because it closes the form itself — the extension
+    detects this flow by the ``returnUrl`` and keeps the button, since here nothing else
+    would bring the user back.
 
 Links that leave the thread open outside the frame
     The share link and the record link would replace the frame with a full backend page, so

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -428,9 +428,13 @@
 				<source>Oldest first</source>
 				<target>Älteste zuerst</target>
 			</trans-unit>
-			<trans-unit id="comment.view.resolved.toggle">
-				<source>Resolved</source>
-				<target>Erledigte</target>
+			<trans-unit id="comment.view.resolved.show">
+				<source>Show resolved</source>
+				<target>Erledigte anzeigen</target>
+			</trans-unit>
+			<trans-unit id="comment.view.resolved.hide">
+				<source>Hide resolved</source>
+				<target>Erledigte ausblenden</target>
 			</trans-unit>
 			<trans-unit id="comment.view.record">
 				<source>Open record</source>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -412,6 +412,34 @@
 				<source><![CDATA[Currently there are no comments available yet. You may want to create a <a data-new-comment-uri="%s" data-table="%s" data-id="%s">new comment</a>?]]></source>
 				<target><![CDATA[Aktuell gibt es keine Kommentare. Du möchtest vielleicht ein <a data-new-comment-uri="%s" data-table="%s" data-id="%s">neuen Kommentar</a> erstellen?]]></target>
 			</trans-unit>
+			<trans-unit id="comment.view.title">
+				<source>Comments</source>
+				<target>Kommentare</target>
+			</trans-unit>
+			<trans-unit id="comment.view.new">
+				<source>New comment</source>
+				<target>Neuer Kommentar</target>
+			</trans-unit>
+			<trans-unit id="comment.view.sort.newest">
+				<source>Newest first</source>
+				<target>Neueste zuerst</target>
+			</trans-unit>
+			<trans-unit id="comment.view.sort.oldest">
+				<source>Oldest first</source>
+				<target>Älteste zuerst</target>
+			</trans-unit>
+			<trans-unit id="comment.view.resolved.toggle">
+				<source>Resolved</source>
+				<target>Erledigte</target>
+			</trans-unit>
+			<trans-unit id="comment.view.record">
+				<source>Open record</source>
+				<target>Datensatz öffnen</target>
+			</trans-unit>
+			<trans-unit id="comment.view.empty">
+				<source>Currently there are no comments available yet.</source>
+				<target>Aktuell gibt es keine Kommentare.</target>
+			</trans-unit>
 
 			<trans-unit id="assignee.selection.label">
 				<source>Select an assignee</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -252,6 +252,27 @@
 			<trans-unit id="comment.empty">
 				<source><![CDATA[Currently there are no comments available yet. You may want to create a <a data-new-comment-uri="%s" data-table="%s" data-id="%s">new comment</a>?]]></source>
 			</trans-unit>
+			<trans-unit id="comment.view.title">
+				<source>Comments</source>
+			</trans-unit>
+			<trans-unit id="comment.view.new">
+				<source>New comment</source>
+			</trans-unit>
+			<trans-unit id="comment.view.sort.newest">
+				<source>Newest first</source>
+			</trans-unit>
+			<trans-unit id="comment.view.sort.oldest">
+				<source>Oldest first</source>
+			</trans-unit>
+			<trans-unit id="comment.view.resolved.toggle">
+				<source>Resolved</source>
+			</trans-unit>
+			<trans-unit id="comment.view.record">
+				<source>Open record</source>
+			</trans-unit>
+			<trans-unit id="comment.view.empty">
+				<source>Currently there are no comments available yet.</source>
+			</trans-unit>
 
 			<trans-unit id="assignee.selection.label">
 				<source>Select an assignee</source>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -264,8 +264,11 @@
 			<trans-unit id="comment.view.sort.oldest">
 				<source>Oldest first</source>
 			</trans-unit>
-			<trans-unit id="comment.view.resolved.toggle">
-				<source>Resolved</source>
+			<trans-unit id="comment.view.resolved.show">
+				<source>Show resolved</source>
+			</trans-unit>
+			<trans-unit id="comment.view.resolved.hide">
+				<source>Hide resolved</source>
 			</trans-unit>
 			<trans-unit id="comment.view.record">
 				<source>Open record</source>

--- a/Resources/Private/Partials/Comment.html
+++ b/Resources/Private/Partials/Comment.html
@@ -24,11 +24,46 @@
             <f:if condition="{showRecordInfo} && !{isReply}">
                 <small>
                     <core:icon identifier="{comment.statusIcon}" size="small" title="{comment.status}"/>
-                    <a href="{comment.recordLink}">
+                    <a href="{comment.recordLink}" target="{f:if(condition: '{embedded}', then: '_top', else: '_self')}">
                         {comment.title}
                     </a>
                 </small>
             </f:if>
+            <f:comment>
+                Embedded mode has no JavaScript: no dropdown to open, no modal to raise, no
+                confirmation to show. Its actions are therefore plain links that navigate
+                the frame and come back via their returnUrl. Delete is deliberately absent
+                here — a one-click irreversible delete without a confirmation step is worse
+                than sending the user to the record itself for it.
+            </f:comment>
+            <f:if condition="{embedded}">
+            <div class="btn-group content-planner-comment__actions content-planner-comment__actions--static">
+                <f:if condition="{comment.canCurrentUserEdit}">
+                    <a class="btn btn-default btn-sm" href="{comment.editUri}"
+                       title="{f:translate(key: 'comment.actions.edit', extensionName: 'XimaTypo3ContentPlanner')}">
+                        <core:icon identifier="actions-open" size="small"/>
+                    </a>
+                </f:if>
+                <f:if condition="{comment.canCurrentUserResolve}">
+                    <f:variable name="status" value="{f:if(condition: '{comment.resolved}', then: 'unresolve', else: 'resolve')}"/>
+                    <a class="btn btn-default btn-sm" href="{comment.resolvedUri}"
+                       title="{f:translate(key: 'comment.actions.{status}', extensionName: 'XimaTypo3ContentPlanner')}">
+                        <core:icon identifier="actions-check-circle" size="small"/>
+                    </a>
+                </f:if>
+                <f:if condition="!{isReply}">
+                    <a class="btn btn-default btn-sm" href="{comment.replyUri}"
+                       title="{f:translate(key: 'comment.actions.reply', extensionName: 'XimaTypo3ContentPlanner')}">
+                        <core:icon identifier="actions-arrow-down-right-alt" size="small"/>
+                    </a>
+                </f:if>
+                <a class="btn btn-default btn-sm" href="{comment.shareUri}" target="_top"
+                   title="{f:translate(key: 'comment.actions.share', extensionName: 'XimaTypo3ContentPlanner')}">
+                    <core:icon identifier="actions-link" size="small"/>
+                </a>
+            </div>
+            </f:if>
+            <f:if condition="!{embedded}">
             <div class="btn-group content-planner-comment__actions">
                 <button type="button" class="btn btn-default dropdown-toggle dropdown-toggle-no-chevron" data-bs-toggle="dropdown"
                         aria-expanded="false">
@@ -95,6 +130,7 @@
                     </f:if>
                 </ul>
             </div>
+            </f:if>
         </div>
         <div class="content-planner-comment__text">{comment.data.content -> f:format.raw()}</div>
         <f:if condition="{comment.resolved}">
@@ -109,23 +145,43 @@
             </div>
         </f:if>
         <f:if condition="{comment.replies}">
-            <a class="content-planner-comment-replies-toggle"
-               data-bs-toggle="collapse" href="#replies-{comment.data.uid}"
-               role="button" aria-expanded="{f:if(condition: '{repliesExpanded}', then: 'true', else: 'false')}" aria-controls="replies-{comment.data.uid}">
-                <core:icon identifier="actions-chevron-right" size="small"/>
-                <span><f:if condition="{comment.replyCount} == 1"><f:then><f:translate key="comment.reply.toggle" extensionName="XimaTypo3ContentPlanner"
-                            arguments="{0: '{comment.lastReplyTimeAgo}'}"/></f:then><f:else><f:translate key="comment.replies.toggle" extensionName="XimaTypo3ContentPlanner"
-                            arguments="{0: '{comment.replyCount}', 1: '{comment.lastReplyTimeAgo}'}"/></f:else></f:if></span>
-            </a>
-            <div class="{f:if(condition: '{repliesExpanded}', then: 'collapse show', else: 'collapse')} content-planner-comment-replies" id="replies-{comment.data.uid}">
+            <f:comment>
+                The collapse is Bootstrap-driven, so embedded mode shows replies outright
+                instead of offering a toggle that could not open.
+            </f:comment>
+            <f:if condition="!{embedded}">
+                <a class="content-planner-comment-replies-toggle"
+                   data-bs-toggle="collapse" href="#replies-{comment.data.uid}"
+                   role="button" aria-expanded="{f:if(condition: '{repliesExpanded}', then: 'true', else: 'false')}" aria-controls="replies-{comment.data.uid}">
+                    <core:icon identifier="actions-chevron-right" size="small"/>
+                    <span><f:if condition="{comment.replyCount} == 1"><f:then><f:translate key="comment.reply.toggle" extensionName="XimaTypo3ContentPlanner"
+                                arguments="{0: '{comment.lastReplyTimeAgo}'}"/></f:then><f:else><f:translate key="comment.replies.toggle" extensionName="XimaTypo3ContentPlanner"
+                                arguments="{0: '{comment.replyCount}', 1: '{comment.lastReplyTimeAgo}'}"/></f:else></f:if></span>
+                </a>
+            </f:if>
+            <f:if condition="{embedded}">
+                <f:then><f:variable name="repliesClass" value=""/></f:then>
+                <f:else><f:variable name="repliesClass" value="{f:if(condition: '{repliesExpanded}', then: 'collapse show', else: 'collapse')}"/></f:else>
+            </f:if>
+            <div class="{repliesClass} content-planner-comment-replies" id="replies-{comment.data.uid}">
                 <f:for each="{comment.replies}" as="reply">
-                    <f:render partial="Comment" arguments="{comment: reply, id: id, table: table, isReply: 1, repliesExpanded: repliesExpanded}" />
+                    <f:render partial="Comment" arguments="{comment: reply, id: id, table: table, isReply: 1, repliesExpanded: repliesExpanded, embedded: embedded}" />
                 </f:for>
-                <button type="button" class="btn btn-default btn-sm content-planner-comment-reply-inline"
-                        data-id="{id}" data-table="{table}" data-reply-comment-uri="{comment.replyUri}">
-                    <core:icon identifier="actions-arrow-down-right-alt" size="small"/>
-                    <f:translate key="comment.actions.reply" extensionName="XimaTypo3ContentPlanner"/>
-                </button>
+                <f:if condition="{embedded}">
+                    <f:then>
+                        <a class="btn btn-default btn-sm content-planner-comment-reply-inline" href="{comment.replyUri}">
+                            <core:icon identifier="actions-arrow-down-right-alt" size="small"/>
+                            <f:translate key="comment.actions.reply" extensionName="XimaTypo3ContentPlanner"/>
+                        </a>
+                    </f:then>
+                    <f:else>
+                        <button type="button" class="btn btn-default btn-sm content-planner-comment-reply-inline"
+                                data-id="{id}" data-table="{table}" data-reply-comment-uri="{comment.replyUri}">
+                            <core:icon identifier="actions-arrow-down-right-alt" size="small"/>
+                            <f:translate key="comment.actions.reply" extensionName="XimaTypo3ContentPlanner"/>
+                        </button>
+                    </f:else>
+                </f:if>
             </div>
         </f:if>
     </div>

--- a/Resources/Private/Partials/Comment.html
+++ b/Resources/Private/Partials/Comment.html
@@ -12,7 +12,7 @@
         <div class="d-flex flex-row justify-content-between gap-2">
             <div class="flex-grow-1">
                 <strong>{comment.authorName}</strong>
-                <small title="{comment.data.crdate -> f:format.date(format:'d.m.Y H:i')}">{comment.timeAgo}</small>
+                <small class="content-planner-comment__time" title="{comment.data.crdate -> f:format.date(format:'d.m.Y H:i')}">{comment.timeAgo}</small>
                 <f:if condition="{comment.edited}">
                     <small class="px-2">
                         <code>

--- a/Resources/Private/Templates/Default/CommentsView.html
+++ b/Resources/Private/Templates/Default/CommentsView.html
@@ -1,0 +1,84 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    data-namespace-typo3-fluid="true">
+
+<f:comment>
+    Standalone counterpart to Default/Comments.html. That template is injected into a
+    backend modal and driven by JavaScript; this one is the body of a complete document
+    rendered for embedding, so every control here is a link. Keeping them separate means
+    the modal path cannot regress when this view changes.
+</f:comment>
+
+<div class="content-planner-comments-view">
+    <div class="content-planner-comments-view__toolbar">
+        <f:if condition="{newCommentUri}">
+            <a class="btn btn-primary btn-sm" href="{newCommentUri}">
+                <core:icon identifier="actions-plus" size="small"/>
+                <f:translate key="comment.view.new" extensionName="XimaTypo3ContentPlanner"/>
+            </a>
+        </f:if>
+
+        <span class="content-planner-comments-view__toolbar-spacer"></span>
+
+        <f:if condition="{comments -> f:count()} || {filter.resolvedCount}">
+            <a class="btn btn-default btn-sm" href="{filter.sortUri}">
+                <f:if condition="{filter.sortComments} == 'DESC'">
+                    <f:then>
+                        <core:icon identifier="actions-sort-amount-down" size="small"/>
+                        <f:translate key="comment.view.sort.newest" extensionName="XimaTypo3ContentPlanner"/>
+                    </f:then>
+                    <f:else>
+                        <core:icon identifier="actions-sort-amount-up" size="small"/>
+                        <f:translate key="comment.view.sort.oldest" extensionName="XimaTypo3ContentPlanner"/>
+                    </f:else>
+                </f:if>
+            </a>
+        </f:if>
+
+        <f:if condition="{filter.resolvedCount}">
+            <a class="btn btn-default btn-sm {f:if(condition: '{filter.showResolvedComments}', then: 'active', else: '')}"
+               href="{filter.toggleResolvedUri}"
+               aria-pressed="{f:if(condition: '{filter.showResolvedComments}', then: 'true', else: 'false')}">
+                <core:icon identifier="actions-check-circle" size="small"/>
+                <f:translate key="comment.view.resolved.toggle" extensionName="XimaTypo3ContentPlanner"/>
+                <span class="badge badge-secondary">{filter.resolvedCount}</span>
+            </a>
+        </f:if>
+
+        <f:comment>
+            Both of these leave the comment thread behind, so they must not replace the
+            embedded frame with a backend page — they open in the top-level window.
+        </f:comment>
+        <f:if condition="{recordUri}">
+            <a class="btn btn-default btn-sm" href="{recordUri}" target="_top">
+                <core:icon identifier="actions-open" size="small"/>
+                <f:translate key="comment.view.record" extensionName="XimaTypo3ContentPlanner"/>
+            </a>
+        </f:if>
+        <f:if condition="{shareUrl}">
+            <a class="btn btn-default btn-sm" href="{shareUrl}" target="_top">
+                <core:icon identifier="actions-link" size="small"/>
+                <f:translate key="comment.actions.share" extensionName="XimaTypo3ContentPlanner"/>
+            </a>
+        </f:if>
+    </div>
+
+    <div class="content-planner-comment-list">
+        <f:if condition="{comments -> f:count()}">
+            <f:then>
+                <f:for each="{comments}" as="record">
+                    <f:render partial="Comment"
+                              arguments="{comment: record, id: id, table: table, isReply: 0, showRecordInfo: 0, repliesExpanded: 1, embedded: 1}"/>
+                </f:for>
+            </f:then>
+            <f:else>
+                <div class="content-planner-widget__empty content-planner-comment-empty">
+                    <f:render partial="Empty"/>
+                    <div class="text-center content-planner-comment-empty__text">
+                        <f:translate key="comment.view.empty" extensionName="XimaTypo3ContentPlanner"/>
+                    </div>
+                </div>
+            </f:else>
+        </f:if>
+    </div>
+</div>
+</html>

--- a/Resources/Private/Templates/Default/CommentsView.html
+++ b/Resources/Private/Templates/Default/CommentsView.html
@@ -34,12 +34,18 @@
             </a>
         </f:if>
 
+        <f:comment>
+            A link, not a toggle button — it navigates. aria-pressed would be ignored on
+            it, so the state lives in the label instead of in an attribute.
+        </f:comment>
         <f:if condition="{filter.resolvedCount}">
             <a class="btn btn-default btn-sm {f:if(condition: '{filter.showResolvedComments}', then: 'active', else: '')}"
-               href="{filter.toggleResolvedUri}"
-               aria-pressed="{f:if(condition: '{filter.showResolvedComments}', then: 'true', else: 'false')}">
+               href="{filter.toggleResolvedUri}">
                 <core:icon identifier="actions-check-circle" size="small"/>
-                <f:translate key="comment.view.resolved.toggle" extensionName="XimaTypo3ContentPlanner"/>
+                <f:if condition="{filter.showResolvedComments}">
+                    <f:then><f:translate key="comment.view.resolved.hide" extensionName="XimaTypo3ContentPlanner"/></f:then>
+                    <f:else><f:translate key="comment.view.resolved.show" extensionName="XimaTypo3ContentPlanner"/></f:else>
+                </f:if>
                 <span class="badge badge-secondary">{filter.resolvedCount}</span>
             </a>
         </f:if>

--- a/Resources/Public/Css/Comments.css
+++ b/Resources/Public/Css/Comments.css
@@ -3,7 +3,7 @@
  *
  * BEM Structure:
  * - content-planner-comment (Block)
- * - content-planner-comment__avatar, __text, __actions (Elements)
+ * - content-planner-comment__avatar, __text, __actions, __time (Elements)
  * - content-planner-comment--resolved (Modifiers)
  */
 
@@ -28,6 +28,14 @@
 
 .content-planner-comment--resolved {
     opacity: 0.6;
+}
+
+/* The relative time sits right after the author name and is short enough to keep on one
+   line. Left to wrap, a narrow container splits it mid-phrase — "1" beside the name and
+   "month ago" on the next line — which reads as a stray number. It may still move to its
+   own line as a whole. */
+.content-planner-comment__time {
+    white-space: nowrap;
 }
 
 .content-planner-comment--highlight {

--- a/Resources/Public/Css/CommentsView.css
+++ b/Resources/Public/Css/CommentsView.css
@@ -1,0 +1,40 @@
+/**
+ * Content Planner - Embeddable Comments View
+ *
+ * Shell styling for the standalone comments document (/content-planner/comments/view).
+ * Loaded on top of backend.css and Comments.css, both of which assume a backend module
+ * around them — this file supplies what that module would otherwise have provided.
+ *
+ * BEM Structure:
+ * - content-planner-comments-view (Block)
+ * - content-planner-comments-view__toolbar, __toolbar-spacer (Elements)
+ */
+
+/* The document is somebody else's iframe, so it owns no margin of its own and inherits
+   the surrounding width. Colours come from backend.css, which resolves them against the
+   data-color-scheme attribute the PageRenderer put on <html>. */
+body {
+    margin: 0;
+    padding: 1rem;
+    background: var(--typo3-component-bg, var(--bs-body-bg));
+    color: var(--bs-body-color);
+}
+
+.content-planner-comments-view__toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.content-planner-comments-view__toolbar-spacer {
+    flex-grow: 1;
+}
+
+/* Comments.css reveals the action group on hover, driven by a class the backend modal's
+   JavaScript sets. This view ships no JavaScript, and hover-only controls are unusable on
+   touch anyway, so the actions stay visible. */
+.content-planner-comment__actions--static {
+    opacity: 1;
+}

--- a/Resources/Public/Css/CommentsView.css
+++ b/Resources/Public/Css/CommentsView.css
@@ -11,13 +11,20 @@
  */
 
 /* The document is somebody else's iframe, so it owns no margin of its own and inherits
-   the surrounding width. Colours come from backend.css, which resolves them against the
-   data-color-scheme attribute CommentsViewController::htmlTagAttributes() puts on <html>. */
+   the surrounding width.
+
+   The colours have to be stated, and they have to be these two. backend.css styles a bare
+   <body> with `color: var(--bs-body-color)`, which is a static #000 taking no part in the
+   colour scheme — a backend module never shows a bare body, its content sits inside
+   .module, so nothing in core has to care. Left alone, dark mode renders black text on a
+   dark background. These are the same custom properties .module resolves --module-bg and
+   --module-color from, so the view follows the platform's scheme handling instead of
+   hardcoding a second answer to it. */
 body {
     margin: 0;
     padding: 1rem;
-    background: var(--typo3-component-bg, var(--bs-body-bg));
-    color: var(--bs-body-color);
+    background-color: var(--typo3-surface-base);
+    color: var(--typo3-text-color-base);
 }
 
 .content-planner-comments-view__toolbar {

--- a/Resources/Public/Css/CommentsView.css
+++ b/Resources/Public/Css/CommentsView.css
@@ -12,7 +12,7 @@
 
 /* The document is somebody else's iframe, so it owns no margin of its own and inherits
    the surrounding width. Colours come from backend.css, which resolves them against the
-   data-color-scheme attribute the PageRenderer put on <html>. */
+   data-color-scheme attribute CommentsViewController::htmlTagAttributes() puts on <html>. */
 body {
     margin: 0;
     padding: 1rem;

--- a/Tests/Functional/Controller/CommentsViewControllerTest.php
+++ b/Tests/Functional/Controller/CommentsViewControllerTest.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Tests\Functional\Controller;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Http\{NormalizedParams, ServerRequest};
+use Xima\XimaTypo3ContentPlanner\Configuration;
+use Xima\XimaTypo3ContentPlanner\Controller\{CommentsViewController, RecordController};
+use Xima\XimaTypo3ContentPlanner\Tests\Functional\AbstractFunctionalTestCase;
+
+use function dirname;
+use function explode;
+use function rawurlencode;
+use function str_contains;
+
+/**
+ * CommentsViewControllerTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class CommentsViewControllerTest extends AbstractFunctionalTestCase
+{
+    /**
+     * The route is registered while the container is built, and the view builds its own
+     * filter URLs through the UriBuilder — so the flag has to be on before the instance
+     * boots, not merely set inside a test method.
+     */
+    protected array $configurationToUseInTestInstance = [
+        'EXTENSIONS' => [
+            Configuration::EXT_KEY => [
+                Configuration::FEATURE_EMBEDDABLE_COMMENTS_VIEW => 1,
+            ],
+        ],
+    ];
+
+    private CommentsViewController $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->importSharedDataSet('status.csv');
+        $this->importCSVDataSet(__DIR__.'/../Service/Fixtures/summary_pages.csv');
+        $this->importCSVDataSet(__DIR__.'/../Service/Fixtures/summary_comments.csv');
+        $this->loginBackendUser();
+        $this->setUpBackendRequest('ximatypo3contentplanner_comments_view');
+        $this->subject = $this->get(CommentsViewController::class);
+    }
+
+    #[Test]
+    public function theRouteIsNotRegisteredWhileTheFlagIsOff(): void
+    {
+        unset($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Configuration::EXT_KEY][Configuration::FEATURE_EMBEDDABLE_COMMENTS_VIEW]);
+
+        self::assertArrayNotHasKey('ximatypo3contentplanner_comments_view', $this->loadRoutes());
+    }
+
+    #[Test]
+    public function theRouteIsRegisteredOnceTheFlagIsOn(): void
+    {
+        $routes = $this->loadRoutes();
+
+        self::assertArrayHasKey('ximatypo3contentplanner_comments_view', $routes);
+        self::assertSame('/content-planner/comments/view', $routes['ximatypo3contentplanner_comments_view']['path']);
+        // Not a public route: the view must stay behind the backend session, unlike the
+        // share route next to it.
+        self::assertArrayNotHasKey('access', $routes['ximatypo3contentplanner_comments_view']);
+    }
+
+    #[Test]
+    public function requiresBothTableAndUid(): void
+    {
+        self::assertSame(400, $this->subject->indexAction($this->viewRequest(['uid' => '1']))->getStatusCode());
+        self::assertSame(400, $this->subject->indexAction($this->viewRequest(['table' => 'pages']))->getStatusCode());
+        self::assertSame(400, $this->subject->indexAction($this->viewRequest(['table' => 'pages', 'uid' => '0']))->getStatusCode());
+    }
+
+    #[Test]
+    public function refusesRecordsTheUserMayNotRead(): void
+    {
+        // Both outcomes match RecordController::commentsAction(): a missing row and a table
+        // the content planner does not track are equally "not found" here.
+        self::assertSame(404, $this->subject->indexAction($this->viewRequest(['table' => 'pages', 'uid' => '9999']))->getStatusCode());
+        self::assertSame(404, $this->subject->indexAction($this->viewRequest(['table' => 'be_users', 'uid' => '1']))->getStatusCode());
+    }
+
+    #[Test]
+    public function refusalsAreStillDocuments(): void
+    {
+        // The response lands in somebody else's iframe, so even an error has to be
+        // renderable there rather than a bare JSON fragment.
+        $body = (string) $this->subject->indexAction($this->viewRequest(['table' => 'pages']))->getBody();
+
+        self::assertStringStartsWith('<!DOCTYPE html>', $body);
+        self::assertStringContainsString('</html>', $body);
+    }
+
+    #[Test]
+    public function rendersACompleteDocument(): void
+    {
+        $body = $this->render();
+
+        self::assertStringStartsWith('<!DOCTYPE html>', $body);
+        self::assertStringContainsString('<head>', $body);
+        self::assertStringContainsString('</body>', $body);
+        self::assertStringContainsString('</html>', $body);
+        self::assertStringContainsString('<html lang=', $body, 'PageRenderer must supply the language attributes');
+    }
+
+    #[Test]
+    public function bringsItsOwnStylesheetsSoTheParentPageNeedsNone(): void
+    {
+        $body = $this->render();
+
+        // backend.css carries the Bootstrap layer the comment markup is written against.
+        self::assertStringContainsString('backend.css', $body);
+        self::assertStringContainsString('Comments.css', $body);
+        self::assertStringContainsString('CommentsView.css', $body);
+    }
+
+    #[Test]
+    public function shipsNoJavaScriptAtAll(): void
+    {
+        // Two reasons, and the second is why this view does not go through PageRenderer:
+        // the consumer's `top` window is a foreign origin, so nothing here may depend on the
+        // backend's JS modules or `top.TYPO3`; and PageRenderer inlines TYPO3.settings,
+        // which carries a CSRF token for every registered backend route.
+        $body = $this->render();
+
+        self::assertStringNotContainsString('<script', $body);
+        self::assertStringNotContainsString('ajaxUrls', $body);
+        self::assertStringNotContainsString('token=', $this->headOf($body), 'no route token may leak into the document head');
+    }
+
+    #[Test]
+    public function followsTheBackendUsersColourScheme(): void
+    {
+        // The <html> attributes are assembled here rather than by the PageRenderer, so the
+        // preference backend.css keys its dark variables off has to be carried over.
+        $GLOBALS['BE_USER']->uc['colorScheme'] = 'dark';
+
+        self::assertStringContainsString('data-color-scheme="dark"', $this->render());
+    }
+
+    #[Test]
+    public function leavesTheColourSchemeToTheSystemWhenTheUserDidNotPickOne(): void
+    {
+        $GLOBALS['BE_USER']->uc['colorScheme'] = 'auto';
+
+        // Same as core: no attribute means "follow prefers-color-scheme".
+        self::assertStringNotContainsString('data-color-scheme', $this->render());
+    }
+
+    #[Test]
+    public function rendersTheCommentThreadIncludingReplies(): void
+    {
+        $body = $this->render();
+
+        self::assertStringContainsString('Open comment', $body);
+        self::assertStringContainsString('Reply', $body);
+        self::assertStringNotContainsString('Deleted comment', $body);
+        // Resolved comments stay hidden until asked for, exactly like the backend modal.
+        self::assertStringNotContainsString('Resolved comment', $body);
+    }
+
+    #[Test]
+    public function showsResolvedCommentsOnRequest(): void
+    {
+        $body = $this->render(['showResolvedComments' => '1']);
+
+        self::assertStringContainsString('Resolved comment', $body);
+    }
+
+    #[Test]
+    public function repliesAreVisibleWithoutABootstrapCollapse(): void
+    {
+        $body = $this->render();
+
+        self::assertStringContainsString('Reply', $body, 'the reply must be rendered, not merely collapsed away');
+        self::assertStringNotContainsString('data-bs-toggle', $body, 'no control may depend on Bootstrap JS');
+        self::assertStringNotContainsString('class="collapse', $body);
+    }
+
+    #[Test]
+    public function actionsAreLinksThatReturnToTheView(): void
+    {
+        $body = $this->render();
+
+        self::assertStringContainsString('record/edit', $body);
+        // returnUrl is derived from the current request and its encoding differs between
+        // TYPO3 versions, so accept either form rather than pinning this environment's.
+        $requestUri = $this->currentRequestUri();
+        self::assertTrue(
+            str_contains($body, 'returnUrl='.$requestUri) || str_contains($body, 'returnUrl='.rawurlencode($requestUri)),
+            'the action links must return to the embeddable view, got: '.$requestUri,
+        );
+        self::assertStringNotContainsString('data-reply-comment-uri', $body, 'the embedded view must not rely on the modal JS');
+        self::assertStringNotContainsString('data-edit-comment-uri', $body);
+    }
+
+    #[Test]
+    public function linksLeavingTheThreadOpenOutsideTheFrame(): void
+    {
+        $body = $this->render();
+
+        // Share and record links replace a whole backend page, which must not happen inside
+        // the consumer's frame.
+        self::assertStringContainsString('target="_top"', $body);
+    }
+
+    #[Test]
+    public function omitsDeleteBecauseItCannotBeConfirmedWithoutJavaScript(): void
+    {
+        self::assertStringNotContainsString('cmd%5Btx_ximatypo3contentplanner_comment%5D', $this->render());
+    }
+
+    #[Test]
+    public function theBackendModalKeepsItsJavaScriptDrivenMarkup(): void
+    {
+        // Regression guard for the shared Comment partial: the embedded branch must not
+        // reach the modal path.
+        $this->setUpBackendRequest('web_layout');
+        $request = (new ServerRequest('https://example.com/typo3/ajax/content-planner/comments', 'GET'))
+            ->withQueryParams(['table' => 'pages', 'uid' => '1']);
+
+        $payload = json_decode((string) $this->get(RecordController::class)->commentsAction($request)->getBody(), true);
+
+        self::assertStringContainsString('data-bs-toggle="dropdown"', $payload['result']);
+        self::assertStringContainsString('data-reply-comment-uri', $payload['result']);
+        self::assertStringContainsString('data-delete-comment-uri', $payload['result']);
+    }
+
+    /**
+     * @param array<string, string> $queryParams
+     */
+    private function render(array $queryParams = []): string
+    {
+        $response = $this->subject->indexAction(
+            $this->viewRequest(['table' => 'pages', 'uid' => '1', ...$queryParams]),
+        );
+        self::assertSame(200, $response->getStatusCode());
+
+        return (string) $response->getBody();
+    }
+
+    /**
+     * @param array<string, string> $queryParams
+     */
+    private function viewRequest(array $queryParams): ServerRequest
+    {
+        return (new ServerRequest('https://example.com/typo3/content-planner/comments/view', 'GET'))
+            ->withQueryParams($queryParams);
+    }
+
+    private function headOf(string $body): string
+    {
+        return (string) (explode('</head>', $body, 2)[0] ?? '');
+    }
+
+    private function currentRequestUri(): string
+    {
+        /** @var NormalizedParams $normalizedParams */
+        $normalizedParams = $GLOBALS['TYPO3_REQUEST']->getAttribute('normalizedParams');
+
+        return $normalizedParams->getRequestUri();
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function loadRoutes(): array
+    {
+        return require dirname(__DIR__, 3).'/Configuration/Backend/Routes.php';
+    }
+}

--- a/Tests/Functional/Controller/CommentsViewControllerTest.php
+++ b/Tests/Functional/Controller/CommentsViewControllerTest.php
@@ -21,8 +21,10 @@ use Xima\XimaTypo3ContentPlanner\Tests\Functional\AbstractFunctionalTestCase;
 
 use function dirname;
 use function explode;
+use function preg_match_all;
 use function rawurlencode;
 use function str_contains;
+use function urldecode;
 
 /**
  * CommentsViewControllerTest.
@@ -210,6 +212,31 @@ final class CommentsViewControllerTest extends AbstractFunctionalTestCase
     }
 
     #[Test]
+    public function theReturnUrlIsRecognisableAsThisViewsOwn(): void
+    {
+        // ModifyButtonBarEventListener tells this flow apart from the backend modal by
+        // matching the returnUrl against Configuration::ROUTE_PATH_COMMENTS_VIEW, and it has
+        // to: without that, the comment form keeps only a save button and a user who
+        // followed one of these links has no way back here. Asserting the signal keeps the
+        // two sides from drifting apart.
+        // The shared helper registers /typo3/index.php as the request URI, and returnUrl is
+        // derived from it — so without a request that actually is this route, the assertion
+        // below would only be testing the test harness.
+        $this->registerRequestOnTheCommentsViewRoute();
+
+        preg_match_all('/returnUrl=([^"&]+)/', $this->render(), $matches);
+
+        self::assertNotEmpty($matches[1], 'the action links must carry a returnUrl');
+        foreach ($matches[1] as $returnUrl) {
+            self::assertStringContainsString(
+                Configuration::ROUTE_PATH_COMMENTS_VIEW,
+                urldecode($returnUrl),
+                'every returnUrl must point back at the comments view',
+            );
+        }
+    }
+
+    #[Test]
     public function linksLeavingTheThreadOpenOutsideTheFrame(): void
     {
         $body = $this->render();
@@ -261,6 +288,25 @@ final class CommentsViewControllerTest extends AbstractFunctionalTestCase
     {
         return (new ServerRequest('https://example.com/typo3/content-planner/comments/view', 'GET'))
             ->withQueryParams($queryParams);
+    }
+
+    /**
+     * Mirrors what the real route looks like: a backend request whose own URI is the
+     * comments view, which is what makes returnUrl point back here in production.
+     */
+    private function registerRequestOnTheCommentsViewRoute(): void
+    {
+        $requestUri = '/typo3'.Configuration::ROUTE_PATH_COMMENTS_VIEW.'?table=pages&uid=1';
+
+        $GLOBALS['TYPO3_REQUEST'] = $GLOBALS['TYPO3_REQUEST']->withAttribute(
+            'normalizedParams',
+            new NormalizedParams(
+                ['HTTP_HOST' => 'example.com', 'REQUEST_URI' => $requestUri],
+                [],
+                '',
+                '',
+            ),
+        );
     }
 
     private function headOf(string $body): string

--- a/Tests/Functional/Controller/CommentsViewControllerTest.php
+++ b/Tests/Functional/Controller/CommentsViewControllerTest.php
@@ -115,7 +115,7 @@ final class CommentsViewControllerTest extends AbstractFunctionalTestCase
         self::assertStringContainsString('<head>', $body);
         self::assertStringContainsString('</body>', $body);
         self::assertStringContainsString('</html>', $body);
-        self::assertStringContainsString('<html lang=', $body, 'PageRenderer must supply the language attributes');
+        self::assertStringContainsString('<html lang=', $body, 'htmlTagAttributes() must supply the language attributes');
     }
 
     #[Test]

--- a/Tests/Unit/Controller/FolderControllerTest.php
+++ b/Tests/Unit/Controller/FolderControllerTest.php
@@ -39,6 +39,11 @@ final class FolderControllerTest extends TestCase
 
     public function testFolderStatusUpdateRouteIsNotPublic(): void
     {
+        // The route file asks the extension configuration whether the embeddable comments
+        // view is enabled, which would otherwise reach for a PackageManager this unit
+        // context has not booted.
+        $this->stubExtensionConfiguration([]);
+
         $routes = require __DIR__.'/../../../Configuration/Backend/Routes.php';
 
         self::assertArrayHasKey('ximatypo3contentplanner_folder_status_update', $routes);
@@ -87,10 +92,18 @@ final class FolderControllerTest extends TestCase
 
     private function enableFilelistSupport(): void
     {
+        $this->stubExtensionConfiguration(['enableFilelistSupport' => true]);
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     */
+    private function stubExtensionConfiguration(array $configuration): void
+    {
         $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
         $extensionConfiguration->method('get')
             ->with(Configuration::EXT_KEY)
-            ->willReturn(['enableFilelistSupport' => true]);
+            ->willReturn($configuration);
         GeneralUtility::addInstance(ExtensionConfiguration::class, $extensionConfiguration);
     }
 

--- a/Tests/Unit/Service/ButtonBar/CommentFormButtonPolicyTest.php
+++ b/Tests/Unit/Service/ButtonBar/CommentFormButtonPolicyTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "xima_typo3_content_planner" TYPO3 CMS extension.
+ *
+ * (c) 2024-2026 Konrad Michalik <hej@konradmichalik.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Xima\XimaTypo3ContentPlanner\Tests\Unit\Service\ButtonBar;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Backend\Template\Components\Buttons\{InputButton, LinkButton};
+use TYPO3\CMS\Core\Localization\LanguageService;
+use Xima\XimaTypo3ContentPlanner\Service\ButtonBar\CommentFormButtonPolicy;
+
+/**
+ * CommentFormButtonPolicyTest.
+ *
+ * @author Konrad Michalik <hej@konradmichalik.dev>
+ * @license GPL-2.0-or-later
+ */
+final class CommentFormButtonPolicyTest extends TestCase
+{
+    private CommentFormButtonPolicy $subject;
+
+    protected function setUp(): void
+    {
+        $languageService = $this->createMock(LanguageService::class);
+        $languageService->method('sL')->willReturn('Save and Close');
+        $GLOBALS['LANG'] = $languageService;
+
+        $this->subject = new CommentFormButtonPolicy();
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['LANG']);
+    }
+
+    #[Test]
+    public function theModalKeepsOnlyTheSaveButtonAndRelabelsIt(): void
+    {
+        $result = $this->subject->apply($this->buttonBar(), keepCloseButton: false);
+
+        self::assertSame(['_savedok'], $this->namesIn($result));
+        self::assertSame('Save and Close', $this->saveButtonIn($result)->getTitle());
+    }
+
+    #[Test]
+    public function theEmbeddedViewKeepsTheCloseButtonToo(): void
+    {
+        $result = $this->subject->apply($this->buttonBar(), keepCloseButton: true);
+
+        // Without the close button there is no way back to the comment thread.
+        self::assertTrue($this->hasCloseButton($result), 'the core close button must survive');
+        self::assertSame(['_savedok'], $this->namesIn($result));
+    }
+
+    #[Test]
+    public function theEmbeddedViewLeavesTheSaveLabelAlone(): void
+    {
+        // "Save and Close" is only true while the modal does the closing; here the button
+        // really only saves, and claiming otherwise sends the user looking for a redirect
+        // that never happens.
+        $result = $this->subject->apply($this->buttonBar(), keepCloseButton: true);
+
+        self::assertSame('Save', $this->saveButtonIn($result)->getTitle());
+    }
+
+    #[Test]
+    public function unrelatedButtonsAreDroppedInBothModes(): void
+    {
+        foreach ([true, false] as $keepCloseButton) {
+            $result = $this->subject->apply($this->buttonBar(), $keepCloseButton);
+
+            self::assertArrayNotHasKey('right', $result, 'the right group is never kept');
+            self::assertFalse(
+                $this->containsTitle($result, 'Delete'),
+                'buttons other than save and close must not survive',
+            );
+        }
+    }
+
+    /**
+     * @return array<string, array<int, array<int, mixed>>>
+     */
+    private function buttonBar(): array
+    {
+        $save = (new InputButton())->setName('_savedok')->setValue('1')->setTitle('Save');
+        $close = (new LinkButton())->setHref('#')->setClasses('t3js-editform-close')->setTitle('Close');
+        $delete = (new LinkButton())->setHref('#')->setTitle('Delete');
+        $viewInRight = (new LinkButton())->setHref('#')->setTitle('View');
+
+        return [
+            'left' => [[$save, 1], [$close, 2], [$delete, 3]],
+            'right' => [[$viewInRight, 1]],
+        ];
+    }
+
+    /**
+     * @param array<string, array<int, mixed>> $result
+     *
+     * @return array<int, string>
+     */
+    private function namesIn(array $result): array
+    {
+        $names = [];
+        foreach ($this->flatten($result) as $button) {
+            if ($button instanceof InputButton) {
+                $names[] = $button->getName();
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * @param array<string, array<int, mixed>> $result
+     */
+    private function saveButtonIn(array $result): InputButton
+    {
+        foreach ($this->flatten($result) as $button) {
+            if ($button instanceof InputButton) {
+                return $button;
+            }
+        }
+
+        self::fail('no save button left');
+    }
+
+    /**
+     * @param array<string, array<int, mixed>> $result
+     */
+    private function hasCloseButton(array $result): bool
+    {
+        foreach ($this->flatten($result) as $button) {
+            if ($button instanceof LinkButton && str_contains($button->getClasses(), 't3js-editform-close')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, array<int, mixed>> $result
+     */
+    private function containsTitle(array $result, string $title): bool
+    {
+        foreach ($this->flatten($result) as $button) {
+            if ($button->getTitle() === $title) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, array<int, mixed>> $result
+     *
+     * @return array<int, InputButton|LinkButton>
+     */
+    private function flatten(array $result): array
+    {
+        $buttons = [];
+        foreach ($result as $group) {
+            foreach ($group as $entry) {
+                $buttons[] = $entry[0];
+            }
+        }
+
+        return $buttons;
+    }
+}


### PR DESCRIPTION
Closes #277 (CP-1) — the last issue of the frontend-API epic.

Renders a record's comment thread as a complete HTML document at
`/content-planner/comments/view?table=…&uid=…`, suitable as the `src` of an
`<iframe>`. Registered only while `enableEmbeddableCommentsView` is on.

## The view carries no JavaScript

An embedded frame's `top` window belongs to the consumer, so nothing here may
depend on `top.TYPO3`, `TYPO3.settings` or the backend's modal machinery. Every
action is a plain link that navigates the frame to `record_edit`/`tce_db` and
returns via `returnUrl`; the filter controls are links too.

## Why it does not use PageRenderer

My first draft built the document with `PageRenderer`, which seemed obvious — it
already supplies the `lang`/`dir`/`data-theme`/`data-color-scheme` attributes,
the nonce and the assets. The "no JavaScript" test caught what that costs:
`PageRenderer::render()` inlines `TYPO3.settings` for every backend request, and
that object holds a URL **including its CSRF token** for every registered
backend AJAX route. This view needs none of them.

**This is blast radius, not a closed hole** — an earlier revision of this PR
described it as a same-origin attack, which was wrong and has been corrected.
A cross-origin embedder can read neither the frame's DOM nor its globals (and
gets no session at all, see below); a same-origin embedder already holds the
backend session and could fetch any token it wanted. The argument that does
hold is narrower: a response built to be handed to other contexts should carry
as little as it can, because it passes through caches, proxy logs, browser
history and screenshots.

The document is therefore **not token-free, and not meant to be** — the comment
actions are backend route links, which carry a route token by construction.
Avoiding `PageRenderer` narrows the exposure from every backend AJAX route to
the handful this view offers. Documented as such.

## Behaviour

- **Self-contained styling** — brings `backend.css` plus the comment styles, so
  the embedding page needs no backend assets
- **Dark/light** — follows the backend user's preference; no attribute on *auto*,
  matching core
- **Create / edit / reply / resolve** — `record_edit` and `tce_db` inside the
  frame, returning through `returnUrl` (RTE preserved)
- **Share and record link** — `target="_top"`, since both would replace the frame
  with a full backend page
- **Delete is not offered** — it cannot ask for confirmation without JavaScript,
  and a one-click irreversible delete is worse than sending the user to the
  record. Called out in the docs.
- **Permissions** — identical to `RecordController::commentsAction()`; refusals
  are documents too, since they land in somebody else's frame

## Two bugs the test suite passed through

Both found by checking the view in a real 13.4 backend, and both fixed here.
Worth reading, because each shows a test asserting the wrong layer.

**Dark mode was unreadable.** The view set `color: var(--bs-body-color)`, which
is a static `#000` in TYPO3's `backend.css` and takes no part in the colour
scheme — black text on `#171717`. Dropping the declaration does not help either:
`backend.css` styles a bare `<body>` with the same static value, and a backend
module never shows a bare body because its content sits inside `.module`. The
view now resolves the same custom properties `.module` does. The existing test
asserted the `data-color-scheme` attribute, which was correct all along; it could
not see that the result was unreadable.

**The edit form had no way back.** `ModifyButtonBarEventListener` strips comment
forms to their save button and labels it "Save and Close" — accurate for the
backend modal, which closes the form itself. Reached through a plain link there
is no such JavaScript: the button only saved, the core close button was gone, and
the user was stranded with a correct but unused `returnUrl`. The listener now
recognises this flow by its `returnUrl` and keeps the close button.

That fix is deliberately narrow. Renaming the button to `_saveandclosedok` would
save a click, but the modal depends on the save re-rendering the form (see the
note about issue #238 in `create-and-edit-comment-modal.js`), so the modal path
is untouched — and verified unchanged in the browser. The button logic moved to
`CommentFormButtonPolicy`, which also brings the listener back under its
complexity budget.

## Documented integration caveat

The backend session cookie is `SameSite=strict` by default, so **cross-origin
embedding does not authenticate** — the frame lands at the login screen.
Same-origin (the motivating case) is unaffected. Relaxing it is a site-wide
decision, so the docs state the trade-off rather than the view making it.

## Notes

- The shared `Comment` partial gained an `embedded` branch; the backend modal
  path is guarded by a regression test asserting it still renders its JS-driven
  markup, and was checked by hand as well.
- `Configuration/Backend/Routes.php` now consults the extension configuration,
  which broke a unit test that `require`s it without a TYPO3 bootstrap. Fixed via
  the `ExtensionConfiguration` stub that test class already had.
- Both cosmetic findings from the manual check are fixed here: the document now
  links the backend favicon (it was requesting /favicon.ico and getting a 404),
  and the relative time no longer splits mid-phrase in a narrow container.
- A pure-JavaScript consumer has no way to discover this URL with its token.
  `UrlUtility::getCommentsViewUrl()` covers PHP callers, which is the motivating
  case (a sitepackage rendering the sidebar server-side). A discovery endpoint
  would be a separate issue if the integration is ever meant to be client-only.

## Test plan

- [x] Unit + functional: `Tests: 422, Assertions: 760, Skipped: 3` (pre-existing
      v14-only skips) plus 168 unit
- [x] Mutation-checked: flipping `embedded: 1` → `0` reddens exactly three tests;
      removing `target="_top"` reddens one more; reverting the button fix reddens
      exactly the two new policy tests and leaves the modal ones green
- [x] PHPStan level 6, php-cs-fixer, Rector dry-run, language lint,
      ComposerRequireChecker
- [x] Manual check in a real 13.4 backend: standalone document (0 script tags,
      three stylesheets, `target="_top"` only on share/record, actions visible,
      no Bootstrap dependency), embedded in a plain `<iframe>` on a page with no
      backend assets, `record_edit` opening in-frame with a working RTE, the
      full create round-trip returning to the thread, dark and light both
      readable, the backend modal unchanged, and the flag-off route redirecting
      to the backend shell as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a standalone, embeddable comments view with responsive styling and theme support.
  - Added controls for creating comments, sorting, showing resolved comments, opening records, and sharing.
  - Added direct links for editing, resolving, replying to, and sharing comments.
  - Added German and English translations for the comments view.
- **Bug Fixes**
  - Improved access validation and safe handling of invalid or unauthorized requests.
  - Embedded views no longer rely on JavaScript and omit unsupported deletion actions.
- **Documentation**
  - Documented embedding requirements, parameters, responses, and security behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
