### PR TITLE
fix: point the status table constant at the status table (#297)

### DIFF
--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -63,7 +63,13 @@ class Configuration
 
     final public const TABLE_FOLDER = 'tx_ximatypo3contentplanner_folder';
     final public const TABLE_COMMENT = 'tx_ximatypo3contentplanner_comment';
-    final public const TABLE_STATUS = 'tx_ximatypo3contentplanner_status';
+
+    /*
+     * Up to and including v3, this held 'tx_ximatypo3contentplanner_status' — the name of
+     * the status *field* below, not of the status table. Nothing compared equal to it, so
+     * DataHandlerHook never cleared a deleted status off the records referencing it.
+     */
+    final public const TABLE_STATUS = 'tx_ximatypo3contentplanner_domain_model_status';
 
     final public const FIELD_STATUS = 'tx_ximatypo3contentplanner_status';
     final public const FIELD_ASSIGNEE = 'tx_ximatypo3contentplanner_assignee';

--- a/Classes/Hooks/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandlerHook.php
@@ -101,6 +101,13 @@ final readonly class DataHandlerHook // @phpstan-ignore-line complexity.classLik
             foreach (ExtensionUtility::getRecordTables() as $recordTable) {
                 $this->statusChangeManager->clearStatusOfExtensionRecords($recordTable, (int) $id);
             }
+
+            // Those are raw writes, so clearCachePostProc() never hears about them: the tags
+            // the DataHandler reports describe the status record, while the cached listings
+            // are tagged by the record tables just emptied. Deleting a status is a rare
+            // administrative action, so flushing the extension's own cache wholesale is
+            // cheaper than working out which rows were touched.
+            $this->cache->flush();
         }
 
         if (Configuration::TABLE_COMMENT === $table) {

--- a/Tests/Functional/Hooks/DataHandlerHookTest.php
+++ b/Tests/Functional/Hooks/DataHandlerHookTest.php
@@ -15,6 +15,7 @@ namespace Xima\XimaTypo3ContentPlanner\Tests\Functional\Hooks;
 
 use PHPUnit\Framework\Attributes\Test;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -32,6 +33,14 @@ use Xima\XimaTypo3ContentPlanner\Tests\Functional\AbstractFunctionalTestCase;
  */
 final class DataHandlerHookTest extends AbstractFunctionalTestCase
 {
+    /**
+     * The table name is spelled out rather than taken from Configuration::TABLE_STATUS on
+     * purpose. This is what the DataHandler actually passes, and the bug being guarded
+     * against was precisely that the constant did not match it — feeding the constant in
+     * here would compare it with itself and pass no matter what it holds.
+     */
+    private const STATUS_TABLE = 'tx_ximatypo3contentplanner_domain_model_status';
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -81,6 +90,103 @@ final class DataHandlerHookTest extends AbstractFunctionalTestCase
         $hook->processDatamap_preProcessFieldArray($fields, Configuration::TABLE_COMMENT, 'NEW456', $dataHandler);
 
         self::assertArrayHasKey('author', $dataHandler->datamap[Configuration::TABLE_COMMENT]['NEW456']);
+    }
+
+    #[Test]
+    public function deletingAStatusClearsItFromEveryTrackedRecord(): void
+    {
+        $this->importSharedDataSet('status.csv');
+        $this->importCSVDataSet(__DIR__.'/../Service/Fixtures/summary_pages.csv');
+        self::assertSame(1, $this->statusOfPage(1), 'fixture must start with page 1 on status 1');
+
+        $this->deleteStatus(1);
+
+        // Without this, records keep pointing at a status whose row is gone — the annotation
+        // survives its own definition.
+        self::assertNull($this->statusOfPage(1), 'deleting a status must clear it from records');
+    }
+
+    #[Test]
+    public function deletingAStatusIsVisibleToTheNextCachedRead(): void
+    {
+        $this->importSharedDataSet('status.csv');
+        $this->importCSVDataSet(__DIR__.'/../Service/Fixtures/summary_pages.csv');
+        $recordRepository = $this->get(RecordRepository::class);
+
+        // Warm the listing cache while page 1 still reports status 1.
+        self::assertSame(1, $this->cachedStatusOfPage($recordRepository, 1));
+
+        $this->deleteStatusWithRealCache(1);
+
+        // The clearing is a raw write, so without an explicit flush the listing keeps
+        // serving a status whose record is gone.
+        self::assertNull($this->cachedStatusOfPage($recordRepository, 1), 'findByPid() served a deleted status');
+    }
+
+    #[Test]
+    public function deletingAStatusLeavesOtherStatusesAlone(): void
+    {
+        $this->importSharedDataSet('status.csv');
+        $this->importCSVDataSet(__DIR__.'/../Service/Fixtures/summary_pages.csv');
+        self::assertSame(3, $this->statusOfPage(2), 'fixture must start with page 2 on status 3');
+
+        $this->deleteStatus(1);
+
+        // The cleanup is scoped to the deleted status, not a blanket reset.
+        self::assertSame(3, $this->statusOfPage(2));
+    }
+
+    private function deleteStatus(int $uid): void
+    {
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $unused = null;
+        $this->createHook()->processCmdmap_preProcess(
+            'delete',
+            self::STATUS_TABLE,
+            $uid,
+            $unused,
+            $dataHandler,
+            null,
+        );
+    }
+
+    /**
+     * The other cases mock the cache away; this one needs the real one, because the flush
+     * is the thing under test.
+     */
+    private function deleteStatusWithRealCache(int $uid): void
+    {
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $unused = null;
+        $hook = new DataHandlerHook(
+            $this->get(CacheManager::class)->getCache(Configuration::CACHE_IDENTIFIER.'_cache'),
+            $this->get(StatusChangeManager::class),
+            $this->get(RecordRepository::class),
+            $this->get(CommentRepository::class),
+            $this->get(EventDispatcherInterface::class),
+        );
+
+        $hook->processCmdmap_preProcess('delete', self::STATUS_TABLE, $uid, $unused, $dataHandler, null);
+    }
+
+    private function cachedStatusOfPage(RecordRepository $recordRepository, int $uid): ?int
+    {
+        foreach ($recordRepository->findByPid('pages', 0) as $row) {
+            if ((int) $row['uid'] === $uid) {
+                return null === $row[Configuration::FIELD_STATUS] ? null : (int) $row[Configuration::FIELD_STATUS];
+            }
+        }
+
+        return null;
+    }
+
+    private function statusOfPage(int $uid): ?int
+    {
+        $value = $this->getConnectionPool()->getConnectionForTable('pages')
+            ->select([Configuration::FIELD_STATUS], 'pages', ['uid' => $uid])
+            ->fetchOne();
+
+        return null === $value || 0 === (int) $value ? null : (int) $value;
     }
 
     private function createHook(): DataHandlerHook


### PR DESCRIPTION
Closes #297.

## The bug

`Configuration::TABLE_STATUS` held `tx_ximatypo3contentplanner_status` — the name of the
status **field**, not of the status table. It was character-for-character identical to
`FIELD_STATUS` directly below it.

`DataHandlerHook::processCmdmap_preProcess()` compares a real table name against it, so the
condition was unsatisfiable and the branch behind it never ran:

```php
if (Configuration::TABLE_STATUS === $table) {
    foreach (ExtensionUtility::getRecordTables() as $recordTable) {
        $this->statusChangeManager->clearStatusOfExtensionRecords($recordTable, (int) $id);
    }
}
```

**Effect:** deleting a status left every page, content element and other tracked record
still carrying that status uid, pointing at a row that was gone. I first took this for dead
code and said so; it is reachable code with an impossible condition, which is worse — the
intended cleanup silently did not happen.

## A second gap the fix exposed

Making the branch run is not sufficient on its own. `clearStatusOfExtensionRecords()` is a
raw `QueryBuilder` update, so `clearCachePostProc()` never learns about it: the tags the
DataHandler reports describe the *status* record, while the cached listings are tagged by
the record tables being emptied. Without an explicit flush the fix would clear the database
and still serve the deleted status from cache.

The extension's own cache is therefore flushed when a status is deleted. That is a rare
administrative action, so a wholesale flush is cheaper than working out which rows were
touched — and it stays correct independently of #294.

## Tests

The deletion path had none, which is why this survived. Three added:

- the status is cleared from tracked records
- the next cached read no longer sees it
- other statuses are left alone (the cleanup is scoped, not a blanket reset)

**The table name is spelled out in the test rather than taken from the constant.** My first
attempt passed `Configuration::TABLE_STATUS` as the table and went green immediately — it
compared the wrong value with itself and would have passed whatever the constant held. That
is exactly the shape of the original bug, so the test now uses what the DataHandler actually
passes.

Mutation-checked: reverting the constant reddens the clearing test, removing the flush
reddens the cache test.

## Compatibility

`TABLE_STATUS` is a `public const`, so its value changing is technically visible to external
callers. Anything using it as a table name was already broken, since it was not one — but it
is worth a line in the release notes.

## Test plan

- [x] Unit + functional: `Tests: 407, Assertions: 705, Skipped: 3` (pre-existing v14-only
      skips) plus 164 unit
- [x] Mutation-checked as described above
- [x] PHPStan level 6, php-cs-fixer, Rector dry-run, language lint,
      ComposerRequireChecker
- [ ] Manual check in a real backend — not done; the functional tests exercise the hook
      directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected status table handling to ensure status records are updated and deleted reliably.
  * Clearing a status now refreshes cached data, preventing outdated status information from being displayed.
  * References to deleted statuses are removed while unrelated statuses remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->